### PR TITLE
Adding Live Stream Link to Narrative Science

### DIFF
--- a/_posts/events/2014-09-09-narrative-science.md
+++ b/_posts/events/2014-09-09-narrative-science.md
@@ -14,6 +14,8 @@ published: true
 
 They'll touch on the data analytics used to produce stories and how the same method could be applied to other types of civic data to find interesting insights.
 
+You can find a live video of this event on the [Smart Chicago YouTube Channel](http://youtu.be/DNiLma9UykU).  
+
 ---
 
 As usual, we will have topic specific working groups to help guide conversations and potential apps:


### PR DESCRIPTION
Adding link to Smart Chicago live event page for this session. The embed code for this post is: 

<iframe width="640" height="360" src="//www.youtube.com/embed/DNiLma9UykU?rel=0" frameborder="0" allowfullscreen></iframe> 


But I'm not sure if you want a video running through this page or not.
