### PR TITLE
Remove petcoke from breakouts list

### DIFF
--- a/breakouts.html
+++ b/breakouts.html
@@ -121,12 +121,6 @@ description: Every week after the presentation, we break out into topic-specific
       <td>An Open Source, Open Data project monitoring the health of Chicago's 27 beaches.</td>
     </tr>
     <tr>
-      <td>Environment</td>
-      <td><a href='http://petcokealerts.org/'>Petcoke Alerts</a></td>
-      <td><a href='http://benwilhelm.com/'><img src='/images/people/ben_wilhelm.png' alt='Ben Wilhelm' title='Ben Wilhelm' class='img-responsive img-rounded breakout-headshot' /> Ben Wilhelm</a></td>
-      <td>We're building an application to alert residents in Chicago's Tenth Ward when air quality is poor due to the nearby KCBX Terminals, a bulk freight facility which maintains and transports <a href='http://switchboard.nrdc.org/blogs/hhenderson/West_view-KCBX.jpg'>large open-air piles of petroleum coke ("petcoke")</a>. Long term plans include direct detection of particulate levels in the air using a mesh network of Arduino-based particle sensors.</td>
-    </tr>
-    <tr>
       <td>Social Service Delivery</td>
       <td><a href='http://www.mrelief.com/'>mRelief</a></td>
       <td>


### PR DESCRIPTION
hacking away at home, but not going to be at the hack night for a while so won't be able to lead a breakout group.
