### PR TITLE
Add link to WIP guide on breakouts page

### DIFF
--- a/breakouts.html
+++ b/breakouts.html
@@ -8,7 +8,10 @@ description: Every week after the presentation, we break out into topic-specific
 
 <p>Every week after the presentation, we break out into topic-specific working and learning groups led by regular facilitators to guide conversations, answer questions, and build teams for civic apps. The groups are split into two types: <a href='#working'>working</a> groups and <a href='#learning'>learning</a> groups.</p>
 
-<p>Want to start your own breakout group? Just announce it at the next hack night and people will vote with their feet!</p>
+<p>
+  Want to start your own breakout group? All you need to do is announce it at the next hack night and people will vote with their feet!
+  We also recommend that you check out our <strong><a href="https://docs.google.com/document/d/1nYdhpguK7dl823u6G6EpN1GhGksHXVd8l_e1RB3FQF4/edit?usp=sharing" target="_blank" rel="noopener">guide to starting a breakout group</a></strong>.
+</p>
 
 <button class="btn btn-danger" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
   <i class='fa fa-question-circle'></i> How do I add to this list?


### PR DESCRIPTION

<img width="966" alt="screen shot 2018-09-22 at 3 29 29 pm" src="https://user-images.githubusercontent.com/1165977/45921068-58cf4180-be7c-11e8-8597-da72951712a4.png">
<img width="326" alt="screen shot 2018-09-22 at 3 29 40 pm" src="https://user-images.githubusercontent.com/1165977/45921069-58cf4180-be7c-11e8-871e-0677a8315145.png">



**Test Plan**
- Tested that the link out works and opens in a new tab