### PR TITLE
create default site rsvp_url variable for eventbrite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,4 @@ timezone: America/Chicago
 gems:
   - jekyll-redirect-from
 future: true
+rsvp_url: https://www.eventbrite.com/e/chi-hack-night-registration-54301395937

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -41,7 +41,7 @@ layout: default
 
       {% if site.time <= page.date %}
         <p>
-          <a class='btn btn-success' href='https://www.eventbrite.com/e/chi-hack-night-registration-54301395937'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
+          <a class='btn btn-success' href='{{site.rsvp_url}}'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
 
           {% if page.agenda %}
             &nbsp;&nbsp;<a class='btn btn-info' href='{{page.agenda}}' target='_blank'><i class='fa fa-file-text-o fa-fw'></i> Agenda</a>

--- a/_posts/events/2019-01-15-tech-month-chicago.md
+++ b/_posts/events/2019-01-15-tech-month-chicago.md
@@ -28,7 +28,7 @@ Melanie Adcock is an experienced sales and marketing professional in the technol
 
 ---
 
-**RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-54301395937) by 12:00 PM (noon). Walk-ins will not be allowed!
+**RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
 **ASL** This event **will** have an American Sign Language interpreter.
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ layout: default
         {% endif %}
         <br />
         {% if site.time <= post.date %}
-          <a class='btn btn-success btn-lg' href="https://www.eventbrite.com/e/chi-hack-night-registration-54301395937" target='_blank'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
+          <a class='btn btn-success btn-lg' href="{{site.rsvp_url}}" target='_blank'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
         {% endif %}
         <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
         <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'><i class='fa fa-file-text-o'></i> Agenda</a>
@@ -185,7 +185,7 @@ layout: default
       <div class='col-sm-4'>
         <div class='well'>
           <h1><i class='fa fa-fw fa-calendar'></i></h1>
-          <p>1. Go to Chi Hack Night. <a href='https://www.eventbrite.com/e/chi-hack-night-registration-54301395937'>We meet every Tuesday at 6pm</a></p>
+          <p>1. Go to Chi Hack Night. <a href='{{site.rsvp_url}}'>We meet every Tuesday at 6pm</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
Currently we have the eventbrite link hard coded in several places including:
- 2 locations on index.html
- the event layout
- once on an individual event html page

This pull request would create a site.rsvp_url variable to store the default eventbrite link so that it can be updated in one place instead of having to manually update in all the locations.

Thoughts @derekeder @drevets ?
