### PR TITLE
Use ASL template in more places (fixes #188, #187)

### DIFF
--- a/_posts/events/2017-01-03-potluck-open-hack.md
+++ b/_posts/events/2017-01-03-potluck-open-hack.md
@@ -23,3 +23,5 @@ Happy New Year! Let's start 2017 off with some proper civic hacking!
 There will be no presentation this week. Instead, we're going to have another civic hacking potluck! If you'd like to bring drinks, snacks or desserts, [fill out your name and what you're bringing here](https://docs.google.com/spreadsheets/d/1fBcPpD2TF7PsDa_J8-g_-Ux5ay6tCE8Earu6llKYsXA/edit#gid=0)! We'll provide the usual empanadas too.
 
 While we eat, we'll build, share, and learn about civic tech!
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2017-01-24-latino-techies-hackathon.md
+++ b/_posts/events/2017-01-24-latino-techies-hackathon.md
@@ -32,7 +32,7 @@ This past November, the all-day hackathon gathered 30 housing advocates, artists
 
 Latin@ Hackathon organizers Luz Chavez and Kara Carrell will give an overview of the event. Noah Moskowitz, Antonio Gutierrez, Henri Idrovo, Shelley Hoover and Janet Gomez, all members of the winning team, will show off their project and how they tackled the question “How can we leverage technology to build renter power?"
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 ---
  

--- a/_posts/events/2017-02-14-potluck-open-hack.md
+++ b/_posts/events/2017-02-14-potluck-open-hack.md
@@ -22,4 +22,4 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2017-02-21-if-you-build-it-will-they-come.md
+++ b/_posts/events/2017-02-21-if-you-build-it-will-they-come.md
@@ -25,4 +25,4 @@ The reality is that there are just too many options out there in the world, and 
 
 [Janice Cho](https://www.linkedin.com/in/janice-m-cho-0572b719/), Design Director at [DevMynd Software](https://www.devmynd.com/), will give a talk premised on answering the question: How might we leverage the design methodologies that constitute Human Centered Design to vet our ideas before we build them?
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2017-02-28-mr-robot-goes-to-washington.md
+++ b/_posts/events/2017-02-28-mr-robot-goes-to-washington.md
@@ -26,7 +26,7 @@ This week at Chi Hack Night, we’ll be looking at data from a less rosy perspec
 
 [Ari Scharg](https://www.linkedin.com/in/ari-scharg-4a30b47/), Partner at Edelson PC will give an overview of the consumer privacy issues facing the tech world, and talk about how privacy laws affect tech firms and startups. He will also touch on the immediate need for technologists to help lawmakers understand these issues, and how to get involved in the legislative process.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 ---
 

--- a/_posts/events/2017-03-07-toni-preckwinkle.md
+++ b/_posts/events/2017-03-07-toni-preckwinkle.md
@@ -27,4 +27,4 @@ President Preckwinkle has been a dedicated community leader for over two decades
 
 President Preckwinkle will talk about strategies for collaborative approaches that can drive positive change in Cook County.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2017-03-14-sandee-kastrul.md
+++ b/_posts/events/2017-03-14-sandee-kastrul.md
@@ -27,6 +27,6 @@ From well-known leaders at major institutions to hyperlocal changemakers at comm
 
 In her talk, Sandee will highlight their stories - what inspires them to strengthen communities through technology and what journeys brought them to their roles and missions.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-03-21-grace-hopper-legends-and-lies.md
+++ b/_posts/events/2017-03-21-grace-hopper-legends-and-lies.md
@@ -29,6 +29,6 @@ While it's true that Grace literally wrote the book on how to program the worldâ
 
 This presentation is part of our [Women in Tech speaker series](https://chihacknight.org/blog/2017/03/07/presenting-the-women-in-tech-speaker-series.html) celebrating Women's History Month. 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-03-28-robin-robinson.md
+++ b/_posts/events/2017-03-28-robin-robinson.md
@@ -26,7 +26,7 @@ In June 2016, as part of their strategy to foster stronger community faith and p
 
 In her talk, Robin will discuss the role she has taken on and the work needed to [rebuild trust between the Chicago Police Department](http://chicagotonight.wttw.com/2016/06/23/robin-robinson-her-new-role-chicago-police-department) and the communities it serves.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-04-04-smart-green-infrastructure-monitoring.md
+++ b/_posts/events/2017-04-04-smart-green-infrastructure-monitoring.md
@@ -31,6 +31,6 @@ With the City of Chicago, the monitoring technology has been deployed at four gr
 
 [Adam Hecktman](https://twitter.com/AdamHecktman), Microsoft’s Director of Technology & Civic Innovation Chicago, [Dana Al-Qadi](https://www.linkedin.com/in/dana-al-qadi-eit-708b01a0), Engineer at AECOM and [Tom Schenk](https://twitter.com/chicagocdo), Chief Data Officer at the City of Chicago will present details on the pilot formation, solution deployed, and initial findings from this effort.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-04-11-redesigning-access-to-michigans-health-and-human-services.md
+++ b/_posts/events/2017-04-11-redesigning-access-to-michigans-health-and-human-services.md
@@ -27,6 +27,6 @@ The [Michigan Department of Health and Human Services](http://www.michigan.gov/m
 
 [Lena Selzer](https://www.linkedin.com/in/lenaselzer/), Design Director at Civilla and [Janice M. Cho](https://www.linkedin.com/in/janice-m-cho-0572b719/), Design Director at DevMynd, will discuss how they delivered an 80% reduction in complexity (words, questions, pages) without any structural shifts in administrative rules, State laws, or Federal regulations.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-04-25-open-hack-and-demo-night.md
+++ b/_posts/events/2017-04-25-open-hack-and-demo-night.md
@@ -12,6 +12,7 @@ event_id: 251
 youtube_id: 
 agenda: https://docs.google.com/document/d/1XkkdpdLihsKzt6frIfuBX-yBId0cd2LQwQvT2s2DVOk/edit#
 sponsor: <a href='https://devbootcamp.com'>Dev Bootcamp</a>
+asl_provided: true
 tags: 
  - openhack
 published: true
@@ -21,6 +22,6 @@ This week will be Open Hack & Demo Night. "Demo Night" is a new-old thing. A few
 
 This is an opportunity for hack nighters and breakout groups to show off projects in progress – to attract potential new members, and inspire people to give the feedback you've been looking for. Demos are short, and don't have formal presentations or slideshows. Come see what your compatriots are working on!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-05-02-ameya-pawar.md
+++ b/_posts/events/2017-05-02-ameya-pawar.md
@@ -13,6 +13,7 @@ event_id: 252
 youtube_id: bmnyeMo-B3M
 agenda: https://docs.google.com/document/d/1mce2VDjHrfcNI8aAgF1fPGgh7Dwnx7agtYzJp5JsCAQ/edit#
 sponsor: <a href='https://google.com'>Google</a>
+asl_provided: true
 tags: 
  - candidate
 published: true
@@ -22,7 +23,7 @@ This week, we’re excited to have 47th Ward Alderman Ameya Pawar join us! As an
 
 Alderman Ameya Pawar is the son of Indian immigrants and the first Asian American to be elected onto the Chicago City Council. Since taking office in 2011 and being reelected with 82% of the vote in 2015, Ameya has secured millions of dollars for schools in his community. Ameya’s work on neighborhood schools—helping families stay in one neighborhood from kindergarten through 12th grade—is seen by many as a model for the city. 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-06-13-open-hack-and-demo-night.md
+++ b/_posts/events/2017-06-13-open-hack-and-demo-night.md
@@ -12,6 +12,7 @@ event_id: 258
 youtube_id: 
 agenda: https://docs.google.com/document/d/1c9SujKuFH8gDLJQRuQhxRIDZH4_tk8bAaL3tqbpI1xk/edit
 sponsor: <a href='http://thecitybase.com'>CityBase</a>
+asl_provided: true
 tags: 
  - openhack
 published: true
@@ -21,6 +22,6 @@ This week will be Open Hack & Demo Night. "Demo Night" is a new-old thing. A few
 
 This is an opportunity for hack nighters and breakout groups to show off projects in progress – to attract potential new members, and inspire people to give the feedback you've been looking for. Demos are short, and don't have formal presentations or slideshows. Come see what your compatriots are working on!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-06-20-brenna-berman.md
+++ b/_posts/events/2017-06-20-brenna-berman.md
@@ -13,6 +13,7 @@ event_id: 259
 youtube_id: ulrLTCrHeeo
 agenda: https://docs.google.com/document/d/1ruyej51hkgfUZFGDBNfJm5fKYSSG5Gd46XFFiU6rtxA/edit?usp=sharing
 sponsor: <a href='http://twilio.com'>Twilio</a>
+asl_provided: true
 tags: 
  - govtech
 published: true
@@ -20,6 +21,6 @@ published: true
 
 Five years leading the second largest municipal IT department in the country is a journey marked by equal parts exhilaration, frustration and pride.  Just two months after leaving her position as CIO, Brenna Berman will be sharing achievements and reflections from her time at the City of Chicago Department of Innovation & Technology.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-06-27-chano4mayor.md
+++ b/_posts/events/2017-06-27-chano4mayor.md
@@ -14,6 +14,7 @@ event_id: 260
 youtube_id: rD7ByPxRdNU
 agenda: https://docs.google.com/document/d/1D1IMj_i1562ywRmaEEFCuPHYvLU8hz9wrmWwbFvhzvQ/edit#
 sponsor: <a href='https://microsoft.com'>Microsoft</a>
+asl_provided: true
 tags:
  - advocacy
  - politics
@@ -22,6 +23,6 @@ published: true
 
 [Jean Cochrane](https://twitter.com/jean_cochrane) and [Alex Soble](https://twitter.com/alexsoble) will talk about their work creating [Chano4Mayor.com](https://chano4mayor.com/). The website proposes that [Chance the Rapper](https://en.wikipedia.org/wiki/Chance_the_Rapper) run for the Mayor of Chicago in the upcoming 2019 elections. The site also explains what's at stakes and engages residents to make sure they're registered. 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-07-11-jb-pritzker.md
+++ b/_posts/events/2017-07-11-jb-pritzker.md
@@ -13,6 +13,7 @@ event_id: 261
 youtube_id: p7tJ4JGYUrU
 agenda: https://docs.google.com/document/d/1jJ9DF_nDUU97U2pFFmV0yXRngUFlZIJ-v5ROcoEI0oQ/edit#
 sponsor: <a href='https://devbootcamp.com'>Dev Bootcamp</a>
+asl_provided: true
 tags: 
  - candidate
 published: true
@@ -25,6 +26,6 @@ This week welcome [JB Pritzker](https://en.wikipedia.org/wiki/J._B._Pritzker), v
 JB will make his case for being our next Governor, and discuss the vision he has for the State of Illinois.
 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-07-18-chicago-history-museum.md
+++ b/_posts/events/2017-07-18-chicago-history-museum.md
@@ -13,6 +13,7 @@ event_id: 262
 youtube_id: IrPwZ7ejsw8
 agenda: https://docs.google.com/document/d/1gNJRxZgfbiGxPQ5C1S7vmyUyZOb0tbEWWjNcEAICj7U/edit#
 sponsor: <a href='https://google.com'>Google</a>
+asl_provided: true
 tags:
  - education
 published: true
@@ -23,6 +24,6 @@ Peter Alter, director of the [Chicago History Museum’s Studs Terkel Center for
 In these projects, elementary, middle, and high school students are the historians. Alter will discuss the highlights as well as the challenges in working on these two efforts.
 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-07-25-cfa-summer-tour.md
+++ b/_posts/events/2017-07-25-cfa-summer-tour.md
@@ -14,6 +14,7 @@ event_id: 263
 youtube_id: nN3veIKCXIQ
 agenda: https://docs.google.com/document/d/1KLgatY5oTQMzXLDweDNoxJba6wvUwXRvtpXtIdvnGuk/edit#
 sponsor: <a href='https://thecitybase.com/'>CityBase</a>
+asl_provided: true
 tags:
  - govtech
 published: true
@@ -23,6 +24,6 @@ Join [Code for America](https://www.codeforamerica.org/) Founder [Jen Pahlka](ht
 
 They will show off a few of their new initiatives, including their [Talent program](https://www.codeforamerica.org/jobs) and the upcoming Brigade Congress event this October.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-08-01-potluck-open-hack.md
+++ b/_posts/events/2017-08-01-potluck-open-hack.md
@@ -22,6 +22,6 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-08-08-summertime-predictions.md
+++ b/_posts/events/2017-08-08-summertime-predictions.md
@@ -26,7 +26,7 @@ Lake Michigan and outdoor recreation are enjoyable aspects of summers in Chicago
 
 This summer, the City of Chicago launched two new predictive analytics projects to forecasts the risks and to proactively limit these risks. Members of the research team, [Tom Schenk Jr.](https://twitter.com/chicagocdo), [Gene Leynes](https://twitter.com/Geneorama) and [Nick Lucius](https://twitter.com/chicagolucius) will discuss the projects and how they’re being used as part of city operations.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-08-15-Gerrymandering-2020.md
+++ b/_posts/events/2017-08-15-Gerrymandering-2020.md
@@ -30,6 +30,6 @@ This talk will cover :
 - why we probably can't draw districts with one, unbiased algorithm
 - open source maps and metrics that Metric Geometry and Gerrymandering Group is developing
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-08-22-chicago-foundation-for-women.md
+++ b/_posts/events/2017-08-22-chicago-foundation-for-women.md
@@ -26,6 +26,6 @@ How do we move Chicago closer to gender parity, and how can data help us get the
 
 Chicago Foundation for Women President and CEO [K. Sujata](https://twitter.com/k_sujata) will share their vision for gender equity, and how the foundation is using data to remove barriers for women and girls.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-08-29-potluck-open-hack.md
+++ b/_posts/events/2017-08-29-potluck-open-hack.md
@@ -22,6 +22,6 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-09-05-senator-daniel-biss.md
+++ b/_posts/events/2017-09-05-senator-daniel-biss.md
@@ -25,6 +25,6 @@ This week welcome [Daniel Biss](https://en.wikipedia.org/wiki/Daniel_Biss), Stat
 
 Senator Biss will make his case for being our next Governor, and discuss the vision he has for the State of Illinois.
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-09-12-eric-vazquez-chi-city-clerk.md
+++ b/_posts/events/2017-09-12-eric-vazquez-chi-city-clerk.md
@@ -29,6 +29,6 @@ Eric Vazquez, Chief Technology Officer for the [Chicago City Clerk](http://www.c
 Eric Vazquez is a native Chicagoan. He studied English at the University of Illinois and proceeded to work in the fast-paced, bubble-bursting Web 1.0 scene. Grateful for an opportunity to serve the people of Chicago, Eric is responsible for bringing together technology across departments, identifying and exploiting new technologies and driving overall Office technology strategy.
 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-09-19-potluck-open-hack.md
+++ b/_posts/events/2017-09-19-potluck-open-hack.md
@@ -22,7 +22,7 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-09-26-disaster-mapping.md
+++ b/_posts/events/2017-09-26-disaster-mapping.md
@@ -28,6 +28,6 @@ First responders need to have good maps to know where things used to be, and whe
 
 Longtime Chi Hack Night member and transportation writer Steven Vance will introduce you to OpenStreetMap, and dive right into a simple editing job. Anyone can do this, and it's beneficial to responders to have you spend a couple of hours, or even 10 minutes every other day, to ensure maps for areas struck by disaster have all the buildings and roads that were there prior to the disaster. 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-10-03-cta.md
+++ b/_posts/events/2017-10-03-cta.md
@@ -29,6 +29,6 @@ How does the CTA plan and schedule to accommodate 1.6 million daily rides for ch
 
 To answer these questions (and more), we welcome [Lok Kwan](https://www.linkedin.com/in/lok-kwan-b772603a/) from Rail Scheduling Design & Development, [Bonnie Fan](https://www.linkedin.com/in/bonniefan/) and [Elias Mechaber](https://www.linkedin.com/in/eliasmechaber/) from Performance Management and [Bryan Post](https://www.linkedin.com/in/bryan-post-21a0842a/) from Data Analytics. 
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-10-10-potluck-open-hack.md
+++ b/_posts/events/2017-10-10-potluck-open-hack.md
@@ -22,6 +22,6 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-10-17-illinois-comptroller-susana-mendoza.md
+++ b/_posts/events/2017-10-17-illinois-comptroller-susana-mendoza.md
@@ -25,6 +25,6 @@ In her talk, Comptroller Mendoza will provide an overview of the technological c
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-10-24-potluck-open-hack.md
+++ b/_posts/events/2017-10-24-potluck-open-hack.md
@@ -22,7 +22,7 @@ There will be no presentation this week. Instead, we're going to have another ci
 
 While we eat, we'll build, share, and learn about civic tech!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-10-31-chi-spook-night.md
+++ b/_posts/events/2017-10-31-chi-spook-night.md
@@ -22,6 +22,6 @@ Oooooh … for the first time, Chi Hack Night falls on October 31st …
 
 Which means it’s time for the spookiest night of civic tech all year! Instead of a presentation, we'll have a game show and some especially haunted breakout groups. Bring some candy/Halloween-themed snacks for breakout group trick-or-treating, and don't forget to wear a costume! We will have some prizes for the best disguises!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-11-07-assessing-chicagos-large-lot-program.md
+++ b/_posts/events/2017-11-07-assessing-chicagos-large-lot-program.md
@@ -41,6 +41,6 @@ Paul and William will discuss the research they have been conducting to collect 
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-11-08-logan-hack-night-1.md
+++ b/_posts/events/2017-11-08-logan-hack-night-1.md
@@ -50,3 +50,5 @@ People are invited to break off into groups and work on projects, discuss potent
 ---
 
 Food will be provided.
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2017-11-14-chicago-copa.md
+++ b/_posts/events/2017-11-14-chicago-copa.md
@@ -30,6 +30,6 @@ Last week, COPA released for the first time an [open data set on the police misc
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-11-28-cook-county-gis.md
+++ b/_posts/events/2017-11-28-cook-county-gis.md
@@ -27,7 +27,7 @@ From property and boundary data, to transportation, social service, and environm
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2017-12-05-danielle-dumerer.md
+++ b/_posts/events/2017-12-05-danielle-dumerer.md
@@ -25,6 +25,6 @@ Danielle will talk about her journey to this role, and the City's future efforts
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2017-12-12-chikinlmarket.md
+++ b/_posts/events/2017-12-12-chikinlmarket.md
@@ -32,6 +32,6 @@ See you Tuesday!
 
 ---
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-01-09-chris-kennedy.md
+++ b/_posts/events/2018-01-09-chris-kennedy.md
@@ -29,7 +29,7 @@ Mr Kennedy will make his case for being our next Governor, and discuss the visio
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.
 

--- a/_posts/events/2018-01-16-inside-the-water-drain.md
+++ b/_posts/events/2018-01-16-inside-the-water-drain.md
@@ -32,6 +32,6 @@ Tribune reporters [Ted Gregory](https://twitter.com/tgregoryreports), [Patrick O
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-01-23-regional-housing-solutions.md
+++ b/_posts/events/2018-01-23-regional-housing-solutions.md
@@ -30,6 +30,6 @@ CMAP Associate Planner [Elizabeth Scott](https://www.linkedin.com/in/elizabethds
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-01-30-the-tax-divide.md
+++ b/_posts/events/2018-01-30-the-tax-divide.md
@@ -31,6 +31,6 @@ The system, which touches every family in the county, was known to be highly reg
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-02-06-alvyn-walker.md
+++ b/_posts/events/2018-02-06-alvyn-walker.md
@@ -32,6 +32,6 @@ Al will talk about his work in bridging the digital divide and making technology
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-02-13-kim-foxx.md
+++ b/_posts/events/2018-02-13-kim-foxx.md
@@ -33,6 +33,6 @@ State's Attorney Foxx will also preview upcoming steps in the process of buildin
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-02-20-fabian-elliott.md
+++ b/_posts/events/2018-02-20-fabian-elliott.md
@@ -33,6 +33,6 @@ The report evaluates the engagement of local Black communities with the tech sec
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-02-27-charlene-carruthers.md
+++ b/_posts/events/2018-02-27-charlene-carruthers.md
@@ -33,6 +33,6 @@ Charlene will also discuss [BYP100's local organizing work](https://byp100.org/)
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-03-06-alya-adamany-woods.md
+++ b/_posts/events/2018-03-06-alya-adamany-woods.md
@@ -32,6 +32,6 @@ A veteran in Chicago policy, business and tech, Alya’s talk will focus on a br
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-03-13-sana-jafri.md
+++ b/_posts/events/2018-03-13-sana-jafri.md
@@ -30,6 +30,6 @@ Sana’s work revolves around how technology can be leveraged for learning and h
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-03-20-vicki-white.md
+++ b/_posts/events/2018-03-20-vicki-white.md
@@ -30,6 +30,6 @@ Volunteers meet every weekend to fulfill requests from women in state and Federa
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-03-27-michelle-frisque-chicago-public-library.md
+++ b/_posts/events/2018-03-27-michelle-frisque-chicago-public-library.md
@@ -31,6 +31,6 @@ Michelle’s talk will explore the role that technology plays in supporting and 
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-04-03-icirr-app.md
+++ b/_posts/events/2018-04-03-icirr-app.md
@@ -31,6 +31,6 @@ After a couple iterations and fifteen months, [the app is ready to launch!](http
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-04-10-potluck-open-hack.md
+++ b/_posts/events/2018-04-10-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-04-17-judy-hertz-midwest-academy.md
+++ b/_posts/events/2018-04-17-judy-hertz-midwest-academy.md
@@ -38,6 +38,6 @@ Then she will discuss with the group the research and data needs of community or
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-04-24-community-feedback-session.md
+++ b/_posts/events/2018-04-24-community-feedback-session.md
@@ -27,6 +27,6 @@ Please join us for a facilitated group discussion to reflect on what we’ve don
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-04-26-logan-hack-night-4.md
+++ b/_posts/events/2018-04-26-logan-hack-night-4.md
@@ -43,3 +43,5 @@ Daniel Kay Hertz(Senior Policy Analyst, Center for Tax and Budget Accountability
 People are invited to break off into groups and work on projects, discuss potential ideas, and share their skills. Members of the Chi Hack Night community will be on site to run several of their breakout groups.
 
 Food will be provided.
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2018-05-01-the-justice-media-project.md
+++ b/_posts/events/2018-05-01-the-justice-media-project.md
@@ -35,6 +35,6 @@ In 2016, the initiative was brought to Chi Hack Night as the [Quantifying Justic
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-05-08-the-hackies.md
+++ b/_posts/events/2018-05-08-the-hackies.md
@@ -43,6 +43,6 @@ Come celebrate, eat, build, share, and learn with us!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-05-15-potluck-open-hack.md
+++ b/_posts/events/2018-05-15-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-05-22-janae-bonsu.md
+++ b/_posts/events/2018-05-22-janae-bonsu.md
@@ -30,6 +30,6 @@ Researcher-organizer and the report’s lead author, [Janae Bonsu](https://twitt
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-05-29-access-to-justice.md
+++ b/_posts/events/2018-05-29-access-to-justice.md
@@ -33,6 +33,6 @@ Access to Justice's goal was to work with EJP, digitize the guide, and build it 
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-06-05-lead-safe.md
+++ b/_posts/events/2018-06-05-lead-safe.md
@@ -42,6 +42,6 @@ We will hear from the leaders of the Lead Safe project on how it was developed i
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-06-12-potluck-open-hack.md
+++ b/_posts/events/2018-06-12-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-06-19-ashlyn-sparrow.md
+++ b/_posts/events/2018-06-19-ashlyn-sparrow.md
@@ -30,6 +30,6 @@ Coming out of [University of Chicago’s Center for Interdisciplinary Inquiry an
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-06-26-shareable.md
+++ b/_posts/events/2018-06-26-shareable.md
@@ -31,6 +31,6 @@ The peer-to-peer, solidarity economy and sharing movements are working to reesta
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-07-10-chattanooga.md
+++ b/_posts/events/2018-07-10-chattanooga.md
@@ -30,6 +30,6 @@ Andrew is visiting Chicago this week to participate in the [Chicago City Solutio
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-07-17-sheena-erete.md
+++ b/_posts/events/2018-07-17-sheena-erete.md
@@ -32,6 +32,6 @@ As tech designers, it is common to approach work in resource-constrained communi
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-07-24-jennifer-brandel.md
+++ b/_posts/events/2018-07-24-jennifer-brandel.md
@@ -30,6 +30,6 @@ Here in Chicago, a promising experiment has been underway since 2012. It's a new
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-07-31-tom-schenk-jr.md
+++ b/_posts/events/2018-07-31-tom-schenk-jr.md
@@ -28,6 +28,6 @@ Tom will share the stories from the past 5 years to celebrate the accomplishment
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-08-07-potluck-open-hack.md
+++ b/_posts/events/2018-08-07-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-08-14-jason-kunesh.md
+++ b/_posts/events/2018-08-14-jason-kunesh.md
@@ -30,6 +30,6 @@ Most importantly, he wants to hear from you: What should be focused on? What cou
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-08-15-logan-hack-night-7.md
+++ b/_posts/events/2018-08-15-logan-hack-night-7.md
@@ -40,3 +40,5 @@ He will also talk about his time as a student at NU and how being artist-friendl
 People are invited to break off into groups and work on projects, discuss potential ideas, and share their skills. Members of the Chi Hack Night community will be on site to run several of their breakout groups.
 
 Food will be provided.
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2018-08-21-derek-eder.md
+++ b/_posts/events/2018-08-21-derek-eder.md
@@ -27,6 +27,6 @@ It is said that Chicago has one of the strongest and most vibrant civic technolo
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-08-28-propublica-parking-tickets.md
+++ b/_posts/events/2018-08-28-propublica-parking-tickets.md
@@ -32,6 +32,6 @@ In advance of this talk, there is data on some 28 million parking and vehicle co
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-09-04-center-on-halsted.md
+++ b/_posts/events/2018-09-04-center-on-halsted.md
@@ -33,6 +33,6 @@ The Center's hope is that through speaking with Chi Hack Night, it can bridge th
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-09-11-potluck-open-hack.md
+++ b/_posts/events/2018-09-11-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-09-18-kyla-williams.md
+++ b/_posts/events/2018-09-18-kyla-williams.md
@@ -31,6 +31,6 @@ In this talk, Kyla Williams, the CEO and president of the Henry Williams Love Fo
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-09-25-potluck-open-hack.md
+++ b/_posts/events/2018-09-25-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 4:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-10-02-citykey.md
+++ b/_posts/events/2018-10-02-citykey.md
@@ -32,6 +32,6 @@ City Clerk [Anna Valencia](https://twitter.com/chicityclerk) will talk about lau
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 4:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-10-09-censusbureau.md
+++ b/_posts/events/2018-10-09-censusbureau.md
@@ -33,6 +33,6 @@ Minnesota, Nebraska, North Dakota, and South Dakota. Prior to joining the Census
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by noon. Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-10-16-christina-whitehouse-bike-lane-uprising.md
+++ b/_posts/events/2018-10-16-christina-whitehouse-bike-lane-uprising.md
@@ -30,6 +30,6 @@ Last year, after graduation, Christina found herself looking for something to fi
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-10-23-potluck-open-hack.md
+++ b/_posts/events/2018-10-23-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 4:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-10-30-salvador-muñoz-all-chicago.md
+++ b/_posts/events/2018-10-30-salvador-muñoz-all-chicago.md
@@ -29,6 +29,6 @@ One way in which it works towards its mission is through data collection and ana
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-11-06-election-night-party-2018.md
+++ b/_posts/events/2018-11-06-election-night-party-2018.md
@@ -35,6 +35,6 @@ Come hack and watch the returns come in as we eat, potluck style! If you’d lik
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-11-10-Community-Tech.md
+++ b/_posts/events/2018-11-10-Community-Tech.md
@@ -26,3 +26,5 @@ published: true
 ---
 
 How can communities leverage data to solve problems? Join us for Nourish (comm)Unity: Community Tech. Chi Hack Night participants will present on the state of civic technology in Chicago and how it can be used to improve life for Chicagoans. Afterwards, a facilitated "World Cafe" activity will ask questions of the community and harvest the results.
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2018-11-13-tonika-johnson-folded-map.md
+++ b/_posts/events/2018-11-13-tonika-johnson-folded-map.md
@@ -30,6 +30,6 @@ This interactive online presence will expand the reach of Folded Map, both withi
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-11-27-better-government-association.md
+++ b/_posts/events/2018-11-27-better-government-association.md
@@ -32,6 +32,6 @@ The raw data used to produce the project is available to users, and the BGA also
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-12-04-potluck-open-hack.md
+++ b/_posts/events/2018-12-04-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-12-11-becoming-a-non-profit.md
+++ b/_posts/events/2018-12-11-becoming-a-non-profit.md
@@ -37,6 +37,6 @@ This is a big step for this community that we hope will open the doors to many m
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2018-12-18-chihacknight-holiday-party.md
+++ b/_posts/events/2018-12-18-chihacknight-holiday-party.md
@@ -47,6 +47,6 @@ Please see the [FAQ](https://docs.google.com/document/d/1cWoZGNNJG-Xfgvd5up8Pu09
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-01-08-vote-equity-project.md
+++ b/_posts/events/2019-01-08-vote-equity-project.md
@@ -31,6 +31,6 @@ The project's goal is to activate Chicagoans to share what they would  change ab
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event **will** have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-01-15-tech-month-chicago.md
+++ b/_posts/events/2019-01-15-tech-month-chicago.md
@@ -30,6 +30,6 @@ Melanie Adcock is an experienced sales and marketing professional in the technol
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event **will** have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-01-22-racial-disparities-IL-traffic-stops.md
+++ b/_posts/events/2019-01-22-racial-disparities-IL-traffic-stops.md
@@ -35,6 +35,6 @@ During this presentation, Rachel Murphy (ACLU) will walk you through the history
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event **will** have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-02-05-documenters-dot-org.md
+++ b/_posts/events/2019-02-05-documenters-dot-org.md
@@ -30,6 +30,6 @@ This new website complements [City Bureau’s](https://www.citybureau.org/) two-
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event **will** have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-02-12-potluck-open-hack.md
+++ b/_posts/events/2019-02-12-potluck-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}})by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-02-19-maudlyne-ihejirika.md
+++ b/_posts/events/2019-02-19-maudlyne-ihejirika.md
@@ -29,6 +29,6 @@ Maudlyne will talk about her experience as a reporter and columnist in Chicago o
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}})by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-02-26-steven-philpott.md
+++ b/_posts/events/2019-02-26-steven-philpott.md
@@ -29,6 +29,6 @@ Join this session that introduces the Array of Opportunity premise, pilot commun
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}})by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-03-05-open-hack.md
+++ b/_posts/events/2019-03-05-open-hack.md
@@ -27,6 +27,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-03-12-chicago-health-atlas.md
+++ b/_posts/events/2019-03-12-chicago-health-atlas.md
@@ -38,6 +38,6 @@ This event is part of our Women's History Month speaker series, which seeks to e
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}})by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-03-19-lorena-mesa.md
+++ b/_posts/events/2019-03-19-lorena-mesa.md
@@ -31,6 +31,6 @@ In her talk, Lorena will be speaking on the ethical questions and quandaries tha
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}})by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-03-26-MAPSCorps.md
+++ b/_posts/events/2019-03-26-MAPSCorps.md
@@ -40,6 +40,6 @@ Request MAPSCorps data: [https://survey.az1.qualtrics.com/jfe/form/SV_78OmFAmydk
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-04-02-election-night-potluck.md
+++ b/_posts/events/2019-04-02-election-night-potluck.md
@@ -28,6 +28,6 @@ As we watch the returns come in, we'll eat and work on projects. If you’d like
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand](https://www.eventbrite.com/e/chi-hack-night-registration-41703945624) by 12:00 PM. Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-04-09-richard-beckwith.md
+++ b/_posts/events/2019-04-09-richard-beckwith.md
@@ -30,6 +30,6 @@ Richard is also an adviser to the Colony 5 Array of Opportunity project, which i
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-04-16-cook-county-assessor.md
+++ b/_posts/events/2019-04-16-cook-county-assessor.md
@@ -34,6 +34,6 @@ There are three steps to reform: 1) identify and document the problem, 2) remove
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-04-23-18F-TTS.md
+++ b/_posts/events/2019-04-23-18F-TTS.md
@@ -33,6 +33,6 @@ On Tuesday, some of the local TTS/18F team will be sharing about the projects â€
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-04-30-forefront-census.md
+++ b/_posts/events/2019-04-30-forefront-census.md
@@ -34,6 +34,6 @@ Forefront’s goal for the Illinois Count Me In 2020 program is to provide educa
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-05-07-illinois-tech-math497.md
+++ b/_posts/events/2019-05-07-illinois-tech-math497.md
@@ -37,6 +37,6 @@ Two teams of applied math and computer science students from Illinois Tech’s M
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-05-14-open-hack.md
+++ b/_posts/events/2019-05-14-open-hack.md
@@ -28,6 +28,6 @@ While we eat, we'll build, share, and learn about civic tech!
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will not have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.

--- a/_posts/events/2019-05-21-meet-the-new-chihacknight.md
+++ b/_posts/events/2019-05-21-meet-the-new-chihacknight.md
@@ -48,6 +48,6 @@ More resources:
 
 **RSVP required** Braintree now requires all attendees to [RSVP beforehand]({{site.rsvp_url}}) by 12:00 PM (noon). Walk-ins will not be allowed!
 
-**ASL** This event will have an American Sign Language interpreter.
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.
 
 **Food** Food and drinks will be provided. We encourage attendees to bring their own water bottles to reduce waste.


### PR DESCRIPTION
Use the 'asl_provided' variable and the corresponding template text in
more places.  After this change, every event post that contained one
of a) the 'asl_provided' variable in its front matter, or b) the
sentence "This event will have an American Sign Language interpreter"
or c) "This event will not have an American Sign Language interpreter"
now uses a standard template that is conditional on the variable.

In cases where the old sentence and variable disagreed, the variable
stays the same (and thus the sentence as displayed is now different,
once the template is processed).  In cases where the variable was
present but there was no sentence, the standard template sentence is
now present.

Posts that had neither the variable nor the sentence are unchanged;
that's mostly posts from 2016 and earlier.