### PR TITLE
renaming the default master branch to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ docker run --rm --label=jekyll --volume=%CD%:/srv/jekyll  -it -p 4000:4000 jekyl
 
 ## Deploying
 
-Deployments are handled by Netlify by pushing to the `master` branch.
+Deployments are handled by Netlify by pushing to the `production` branch.
 
-Whenver a branch is merged into `master`, or a commit is pushed to `master` it will trigger a Netlify deploy.
+Whenver a branch is merged into `production`, or a commit is pushed to `production` it will trigger a Netlify deploy.
 
 ## Workflow
 The Chi Hack Night web team manages bugs, new features and site development through the [GitHub project board](https://github.com/chihacknight/chihacknight.org/projects/2).
 
-To ensure high code quality, we practice using pull requests and having at least one member of the web team review them before merging in to `master`. 
+To ensure high code quality, we practice using pull requests and having at least one member of the web team review them before merging in to `production`. 
 
 ## Protocols
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,4 +55,4 @@ Before taking photographs Chi Hack Night participants, please ask for verbal app
 
 Created collaboratively by the Chi Hack Night community, adapted from the [Code for America Code of Conduct](https://github.com/codeforamerica/codeofconduct).
 
-*Version 1.3. Published on Feb 25, 2019. This Code of Conduct is licensed to the public under a [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) license. [View the change history on GitHub](https://github.com/chihacknight/chihacknight.org/commits/master/code-of-conduct.md)*
+*Version 1.3. Published on Feb 25, 2019. This Code of Conduct is licensed to the public under a [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) license. [View the change history on GitHub](https://github.com/chihacknight/chihacknight.org/commits/production/code-of-conduct.md)*


### PR DESCRIPTION
We are renaming the default `master` branch to `production`.

Chi Hack Night stands in solidarity with the Black Lives Matter movement. We commit to the fight to end systemic racism and injustice. You can read more about our stance here: https://chihacknight.org/blog/2020/06/06/black-lives-matter.html

We are making this small change to remove the unnecessary reference of `master`, a term that invokes human slavery and contributes to making our community and work less inclusive, from our code.

You can read more about the context about this name change here:

* https://www.theregister.com/2020/06/15/github_replaces_master_with_main/
* https://twitter.com/mislav/status/1270388510684598272
* https://www.theregister.com/2020/06/08/developers_renew_push_to_get/

If you want to make a similar change to your repositories, you can do so by following these steps:

1. On your local machine, check out the latest code from your `master` branch `git pull origin master`
2. Rename your local master branch to your new branch name. In our case, we chose `production`: `git branch -m master production`
3. Push that branch up to GitHub: `git push origin production`
4. Navigate to your project settings page on GitHub and go to the Branches settings. There you can change the default branch to your new `production` branch.
5. Back on your local machine, you can delete the `master` branch now `git push origin :master`.
6. Update your Readme (like I'm doing in this PR) and change all references to your new branch name. 
7. If you have any web or deploy hooks, you may also need to update your settings there. For us, we had to change the deploy branch in our Netlify settings.