### PR TITLE
open hack event for 422

### DIFF
--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -41,11 +41,9 @@ layout: default
 
       {% if site.time <= page.date %}
         <p>
-          <a class='btn btn-success' href='{{site.rsvp_url}}'><i class='fa fa-check-square-o'></i> RSVP</a>
+          <a class='btn btn-link' href="https://bit.ly/chn-remote-zoom" target='_blank'>Zoom call @ 7pm</a>
 
-          &nbsp;&nbsp;<a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream</a>
-
-          <a class='btn btn-link' href="{{page.agenda}}" target='_blank'><i class='fa fa-file-text-o'></i> Agenda</a>
+          <a class='btn btn-link' href="{{page.agenda}}" target='_blank'>Agenda</a>
 
         </p>
 
@@ -53,11 +51,11 @@ layout: default
           <li>
             <strong>6:30pm: ChiCommons/Chi Hack Night Pre-Party</strong><br />Socialize, touch base, and share what you plan on doing at Chi Hack Night <a href="https://bit.ly/CHN-pre-party">bit.ly/CHN-pre-party</a>
           </li>
-          <li>
+         <!--  <li>
             <strong>7:00pm: Livestream presentation starts</strong><br /> Announcements and feature presentation with Q&amp;A <a href="https://youtube.com/chihacknight/live">youtube.com/chihacknight/live</a>
-          </li>
+          </li> -->
           <li>
-            <strong>8:00pm: Open zoom call</strong> 3-word intros, community announcements &amp; breakout group pitches <a href="https://bit.ly/chn-remote-zoom">bit.ly/chn-remote-zoom</a>
+            <strong>7:00pm: Open zoom call</strong> 3-word intros, community announcements &amp; breakout group pitches <a href="https://bit.ly/chn-remote-zoom">bit.ly/chn-remote-zoom</a>
           </li>
         </ul>
       {% else %}

--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -131,8 +131,8 @@ layout: default
           <strong>Location</strong><br />
           {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
           <div itemprop="location" itemscope itemtype="http://schema.org/Place">
-            <!-- <span itemprop="name">Chi Hack Night Zoom Call</span><br /> -->
-            <span itemprop="name">Chi Hack Night YouTube Livestream</span><br />
+            <span itemprop="name">Chi Hack Night Zoom Call</span><br />
+            <!-- <span itemprop="name">Chi Hack Night YouTube Livestream</span><br /> -->
             <!-- <a href='https://maps.google.com/maps?q=222+W+Merchandise+Mart+Plz+Chicago'>
               <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
                 <span itemprop="streetAddress">222 W Merchandise Mart Plz

--- a/_posts/events/2020-11-17-open-hack.md
+++ b/_posts/events/2020-11-17-open-hack.md
@@ -1,0 +1,33 @@
+---
+layout: remote_event
+categories:
+  - events
+links: 
+title: "Open Hack"
+description: "There will be no presentation this week. Instead, we're going to have our first Open Hack since Feb 11. Join our 7pm open Zoom call for introductions, socializing, announcements and breakout groups."
+speakers:
+image: /images/logo/logo-star-social.jpg
+image_credit:
+date: 2020-11-17T19:00:00-06:00
+event_id: 422
+youtube_id: 
+agenda: https://docs.google.com/document/d/1bWW5yhs365soWvBhen0o63mbypReT-Se-Tf2Ep9xaBE/edit#
+sponsor: Chi Hack Night Community
+asl_provided: false
+tags: 
+published: true
+
+---
+
+There will be no presentation this week. Instead, we're going to have our first Open Hack since Feb 11.
+
+Join our 7pm open Zoom call at [bit.ly/chn-remote-zoom](https://bit.ly/chn-remote-zoom). Here's the agenda:
+
+1. Welcome and introductions
+2. Socializing in small groups to meet and get to know your fellow hack night-ers
+3. Announcements from Chi Hack Night and attendees
+4. Breakout group pitches
+
+---
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/index.html
+++ b/index.html
@@ -86,12 +86,9 @@ layout: default
           <p>{{ post.description }}</p>
         {% endif %}
         <br />
-        {% if site.time <= post.date %}
-          <a class='btn btn-success btn-lg' href="{{site.rsvp_url}}" target='_blank'><i class='fa fa-check-square-o'></i> RSVP</a>
-        {% endif %}
         <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
-        <a class='btn btn-link btn-lg' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
-        <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'><i class='fa fa-file-text-o'></i> Agenda</a>
+        <a class='btn btn-link btn-lg' href="https://bit.ly/chn-remote-zoom" target='_blank'>Zoom call @ 7pm</a>
+        <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
       </div>
       <div class='col-sm-5'>
         {% if post.image %}


### PR DESCRIPTION
In addition to the event page, I also made a few changes to the home page and remote_event template to accommodate the different format.

Things to revert for the next event:
* `index.html` - changed the livestream link to the zoom link
* `_layouts/remote_event.html` - commented out livestream link, swapped out the livestream link for the zoom link

I also removed the RSVP link since people aren't really RSVPing anymore.