### PR TITLE
adds future posts and logig to display them on the home page

### DIFF
--- a/_posts/events/2021-05-25-celebrate-argyle.md
+++ b/_posts/events/2021-05-25-celebrate-argyle.md
@@ -20,7 +20,7 @@ youtube_id: 9onfS5X0y74
 agenda: https://docs.google.com/document/d/1js-WQIMBgSD6G5cm6C7CtIXeAN9T6b85ADgElbvw3Q8/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'equity'
 published: true
 
 ---

--- a/_posts/events/2021-06-08-digital-security-101.md
+++ b/_posts/events/2021-06-08-digital-security-101.md
@@ -16,7 +16,7 @@ youtube_id: KN8UfaP7tMw
 agenda: https://docs.google.com/document/d/1AXw5ofEyfu6RbCHVBZS5wNVarq07NOz5b7clpTVluVQ/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'digital security'
 published: true
 
 ---

--- a/_posts/events/2021-06-15-andre-vasquez.md
+++ b/_posts/events/2021-06-15-andre-vasquez.md
@@ -15,7 +15,7 @@ youtube_id: Zj4UsOdgBvU
 agenda: https://docs.google.com/document/d/1X7MMHdQzSlzEubLGS9ugvTASI4Q0r7gPFsDrk5UCMM8/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'budgeting'
 published: true
 
 ---

--- a/_posts/events/2021-06-22-chicag-cityscape.md
+++ b/_posts/events/2021-06-22-chicag-cityscape.md
@@ -16,7 +16,7 @@ youtube_id: p_YiMRZ8lj8
 agenda: https://docs.google.com/document/d/10-gRuE-zizA9vsKyzqqfsLNT3nQXL1yGbZMYPTMaxAQ/edit#
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'real estate'
 published: true
 
 ---

--- a/_posts/events/2021-07-13-chicago-justice-project.md
+++ b/_posts/events/2021-07-13-chicago-justice-project.md
@@ -17,6 +17,8 @@ agenda: https://docs.google.com/document/d/1ZmDnPcI38SPKUtmLVm_FfFa9LBC9lMYc23kn
 sponsor: Chi Hack Night Community
 asl_provided: false
 tags: 
+ - 'public safety'
+ - 'oversight'
 published: true
 
 ---

--- a/_posts/events/2021-07-27-ann-lui.md
+++ b/_posts/events/2021-07-27-ann-lui.md
@@ -15,7 +15,7 @@ youtube_id:
 agenda: https://docs.google.com/document/d/1ZtaEZ8gP_vruclGVJtwovGzXpUb6dST_MHVsJmQLDSg/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'architecture'
 published: true
 
 ---

--- a/_posts/events/2021-08-10-urban-air-chicago.md
+++ b/_posts/events/2021-08-10-urban-air-chicago.md
@@ -20,7 +20,7 @@ youtube_id: Q8Rk7Wuq1kk
 agenda: https://docs.google.com/document/d/1ZbbDQ9QivEbuXl9VP5n6oOUOypbVbcemtqpfu7FujXE/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'environment'
 published: true
 
 ---

--- a/_posts/events/2021-08-17-alex-keefe.md
+++ b/_posts/events/2021-08-17-alex-keefe.md
@@ -15,7 +15,7 @@ youtube_id: 506gEfTS8vw
 agenda: https://docs.google.com/document/d/1G7J5Y1324gJnjEj0yy5DW4c8a5o90Qd4zPUUekJI0e0/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'journalism'
 published: true
 
 ---

--- a/_posts/events/2021-08-24-rebecca-williams.md
+++ b/_posts/events/2021-08-24-rebecca-williams.md
@@ -11,11 +11,11 @@ image: /images/events/458-rebecca.jpg
 image_credit:
 date: 2021-08-24T19:00:00-05:00
 event_id: 458
-youtube_id: 
+youtube_id: aL0HDlaoBFA
 agenda: https://docs.google.com/document/d/12QaF3qAtyMJK2QYXdgNITVme4of3-NW7BeXrd84k11M/edit?usp=sharing
 sponsor: Chi Hack Night Community
 asl_provided: false
-tags: 
+tags: 'smart cities'
 published: true
 
 ---

--- a/_posts/events/2021-09-07-chicommons.md
+++ b/_posts/events/2021-09-07-chicommons.md
@@ -1,0 +1,26 @@
+---
+layout: remote_event
+categories:
+  - events
+links: 
+title: "ChiCommons LWCA"
+description: ''
+speakers:
+image: 
+image_credit:
+date: 2021-09-07T19:00:00-05:00
+event_id: 460
+youtube_id: 
+agenda: 
+sponsor: Chi Hack Night Community
+asl_provided: false
+tags: 
+published: true
+
+---
+
+
+
+---
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2021-09-14-code-your-dreams.md
+++ b/_posts/events/2021-09-14-code-your-dreams.md
@@ -1,0 +1,26 @@
+---
+layout: remote_event
+categories:
+  - events
+links: 
+title: "Code Your Dreams"
+description: ''
+speakers:
+image: 
+image_credit:
+date: 2021-09-14T19:00:00-05:00
+event_id: 461
+youtube_id: 
+agenda: 
+sponsor: Chi Hack Night Community
+asl_provided: false
+tags: 
+published: true
+
+---
+
+
+
+---
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2021-09-21-uic-civic-analytics.md
+++ b/_posts/events/2021-09-21-uic-civic-analytics.md
@@ -1,0 +1,26 @@
+---
+layout: remote_event
+categories:
+  - events
+links: 
+title: "UIC Civic Analytics"
+description: ''
+speakers:
+image: 
+image_credit:
+date: 2021-09-21T19:00:00-05:00
+event_id: 462
+youtube_id: 
+agenda: 
+sponsor: Chi Hack Night Community
+asl_provided: false
+tags: 
+published: true
+
+---
+
+
+
+---
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/_posts/events/2021-09-28-openhack.md
+++ b/_posts/events/2021-09-28-openhack.md
@@ -1,0 +1,33 @@
+---
+layout: remote_event_openhack
+categories:
+  - events
+links: 
+title: "Open Hack"
+description: "There will be no presentation this week. Instead, we're going to have an Open Hack. Join our 7pm open Zoom call for introductions, socializing, announcements and breakout groups."
+speakers:
+image: /images/logo/logo-star-social.jpg
+image_credit:
+date: 2021-09-28T19:00:00-05:00
+event_id: 463
+youtube_id: 
+agenda: 
+sponsor: Chi Hack Night Community
+asl_provided: false
+tags: openhack
+published: true
+
+---
+
+There will be no presentation this week. Instead, we're going to have an Open Hack.
+
+Join our 7pm open Zoom call at [bit.ly/chn-remote-zoom](https://bit.ly/chn-remote-zoom). Here's the agenda:
+
+1. Welcome and introductions
+2. Socializing in small groups to meet and get to know your fellow hack night-ers
+3. Announcements from Chi Hack Night and attendees
+4. Breakout group pitches
+
+---
+
+**ASL** This event will {% unless page.asl_provided %} not {% endunless %}have an American Sign Language interpreter.

--- a/index.html
+++ b/index.html
@@ -73,37 +73,43 @@ layout: default
     <h3 class="panel-title"><b>Next Chi Hack Night</b> <a class='pull-right' href='/events/'>Past events &raquo;</a></h3>
   </div>
   <div class="panel-body">
-    {% for post in site.categories['events'] limit:1 %}
-    <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
+    {% capture current_time %}{{ 'now' | date: "%s" }}{% endcapture %}
+    {% capture in_six_days%}{{ 'now' | date: "%s" | plus : 518400 }}{% endcapture %}
 
-    <h2 class='no-margin-top'>
-      <small>#{{post.event_id}}</small>
-      <a href="{{post.url}}">{{post.title}}</a>
-    </h2>
-    <div class='row'>
-      <div class='col-sm-7'>
-        {% if post.description %}
-          <p>{{ post.description }}</p>
-        {% endif %}
-        <br />
-        <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
-        {% if post.layout == "remote_event_openhack" %}
-          <a class='btn btn-link btn-lg' href="https://bit.ly/chn-remote-zoom" target='_blank'><i class='fa fa-play-circle'></i> Chi Hack Night Zoom Call @ 7pm</a>
-        {% else %}
-          <a class='btn btn-link btn-lg' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
-        {% endif %}
-        <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
-      </div>
-      <div class='col-sm-5'>
-        {% if post.image %}
-          <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
-          {% if post.image_credit %}
-            <br /><small class='pull-right'><em>Photo: {{ post.image_credit }}</em></small>
-          {% endif %}
-        {% endif %}
-      </div>
-    </div>
-      {% endfor %}
+    {% for post in site.categories['events'] limit:10 %}
+      {% capture post_time %}{{ post.date | date: "%s" }}{% endcapture %}
+      {% if post_time <= in_six_days and post_time >= current_time %}
+        <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
+
+        <h2 class='no-margin-top'>
+          <small>#{{post.event_id}}</small>
+          <a href="{{post.url}}">{{post.title}}</a>
+        </h2>
+        <div class='row'>
+          <div class='col-sm-7'>
+            {% if post.description %}
+              <p>{{ post.description }}</p>
+            {% endif %}
+            <br />
+            <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
+            {% if post.layout == "remote_event_openhack" %}
+              <a class='btn btn-link btn-lg' href="https://bit.ly/chn-remote-zoom" target='_blank'><i class='fa fa-play-circle'></i> Chi Hack Night Zoom Call @ 7pm</a>
+            {% else %}
+              <a class='btn btn-link btn-lg' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+            {% endif %}
+            <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
+          </div>
+          <div class='col-sm-5'>
+            {% if post.image %}
+              <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
+              {% if post.image_credit %}
+                <br /><small class='pull-right'><em>Photo: {{ post.image_credit }}</em></small>
+              {% endif %}
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
   </div>
 </div>
 


### PR DESCRIPTION
Per our discussion at the last board meeting, this PR adds future event pages as placeholder stubs. 

The home page is also updated to look at the 10 most recent posts and then display the one that happens fewer than 6 days from now (assuming we keep the current event on the home page until wednesday).

Some tricks I used:
* date calculation in Jekyll/Liquid: https://stackoverflow.com/questions/21056965/date-math-manipulation-in-liquid-template-filter
* the `capture` tag for storing computed values using filters: https://shopify.github.io/liquid/tags/variable/

Potential drawbacks:
* the home page will only update at compile / deploy time. we will need to trigger deploys on wednesdays. it would be worth looking into a way to automate this
* this approach won't display any events that are more than a week out. meaning, weeks we take off will still have to be manually updated. with this kind of logic, we could theoretically automate this better and always show the next upcoming event even if its more than a week out

unrelated, also adds tags and youtube ids to several past posts

@shua123 take a look and give this some tests to make sure it works as we'd expect / like to