### PR TITLE
reduce height of youtube videos

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -20,7 +20,7 @@ layout: default
     {% endif %}
 
       {% if page.youtube_id %}
-        <iframe width="100%" height="580" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
+        <iframe width="100%" height="480" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
         <hr />
       {% elsif site.time >= page.date and page.image %}
         <p>

--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -20,7 +20,7 @@ layout: default
     {% endif %}
 
       {% if page.youtube_id %}
-        <iframe width="100%" height="580" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
+        <iframe width="100%" height="480" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
         <hr />
       {% elsif site.time >= page.date and page.image %}
         <p>

--- a/_layouts/remote_event_openhack.html
+++ b/_layouts/remote_event_openhack.html
@@ -20,7 +20,7 @@ layout: default
     {% endif %}
 
       {% if page.youtube_id %}
-        <iframe width="100%" height="580" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
+        <iframe width="100%" height="480" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
         <hr />
       {% elsif site.time >= page.date and page.image %}
         <p>

--- a/_layouts/satellite_event.html
+++ b/_layouts/satellite_event.html
@@ -19,7 +19,7 @@ layout: default
     {% endif %}
 
       {% if page.youtube_id %}
-        <iframe width="100%" height="580" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
+        <iframe width="100%" height="480" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
         <hr />
       {% elsif site.time >= page.date and page.image %}
         <p>

--- a/_layouts/technexus_event.html
+++ b/_layouts/technexus_event.html
@@ -20,7 +20,7 @@ layout: default
     {% endif %}
 
       {% if page.youtube_id %}
-        <iframe width="100%" height="580" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
+        <iframe width="100%" height="480" src="https://www.youtube.com/embed/{{page.youtube_id}}" frameborder="0" allowfullscreen></iframe>
         <hr />
       {% elsif site.time >= page.date and page.image %}
         <p>


### PR DESCRIPTION
YouTube videos were set to be 580px tall, which caused them to be cropped a bit awkwardly on standard screen sizes

Before:
<img width="1048" alt="Screen Shot 2022-03-24 at 9 20 27 PM" src="https://user-images.githubusercontent.com/919583/160041903-0a5eb9a9-bd47-482d-ad57-2f7c441ac1eb.png">



This PR reduces that height, reducing the cropping for most screen sizes.

After:
<img width="1051" alt="Screen Shot 2022-03-24 at 9 20 20 PM" src="https://user-images.githubusercontent.com/919583/160041933-e8480522-6ca0-4eeb-b7f3-b5ea96269847.png">


