### PR TITLE
fix: update host location for in person events

### DIFF
--- a/about.html
+++ b/about.html
@@ -90,7 +90,7 @@ description: Chi Hack Night is a free, weekly event in Chicago to build, share a
     <p>Chi Hack Night is organized by the <strong><a href='/board-of-directors.html'>Chi Hack Night Board of Directors</a></strong>. They are responsible for governing our organization, as well as running our events, managing our website, keeping the books, and doing all the other things needed to make Chi Hack Night happen.</p>
 
     <strong>Finances</strong><br />
-    <p>Chi Hack Night is hosted at <a href='https://www.braintreepayments.com/'>Braintree</a> and supported by our amazing <a href='/index.html#sponsors'>sponsors</a>. Through May 2019, <a href='https://datamade.us/'>DataMade</a> has been our fiscal sponsor and handled all of our financial transactions.</p>
+    <p>Chi Hack Night is hosted at <a href='https://teamworking.vc/'>TeamWorking</a> and supported by our amazing <a href='/index.html#sponsors'>sponsors</a>. Through May 2019, <a href='https://datamade.us/'>DataMade</a> has been our fiscal sponsor and handled all of our financial transactions.</p>
 
     <p>Chi Hack Night NFP is a 501(c)(3) charitable organization as of April 2020.</p>
 


### PR DESCRIPTION
- Updated the host location from BrainTree to TeamWorking under the finances section on [this page](https://chihacknight.org/about.html)

Before:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/4494915/193934725-e6468721-2a64-4fa0-a696-dfc42e688cbd.png">


After:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/4494915/193934665-88aff1c0-dede-41d5-92d5-52eb34a8ffe0.png">
