### PR TITLE
using container-fluid, making use of more page width

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class='row'>
-  <div class="col-sm-12 post">
+  <div class="col-sm-10 col-sm-offset-1 post">
     <h2>
       {{ page.title }}
     </h2>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -133,7 +133,7 @@
   <body>
 
     <nav class="navbar navbar-inverted navbar-static-top">
-      <div class="container">
+      <div class="container-fluid">
         <div class='col-sm-10 col-sm-offset-1'>
           <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
@@ -161,7 +161,7 @@
     </nav>
 
 
-    <div class="container">
+    <div class="container-fluid">
       <div id='primary-content' class='col-sm-10 col-sm-offset-1'>
 
         {{content}}
@@ -169,7 +169,7 @@
       </div>
     </div> <!-- /container -->
     <footer class="footer">
-      <div class="container">
+      <div class="container-fluid">
         <div class='row'>
           <div class='col-sm-2 col-sm-offset-1'>
             <small>

--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -87,9 +87,6 @@ layout: default
       {% endif %}
 
       <hr />
-      <!-- {% if page.agenda %}
-        <i class='fa fa-file-text-o fa-fw'></i> <a href='{{page.agenda}}' target='_blank'>Agenda and meeting notes</a><br />
-      {% endif %} -->
       {% if site.time <= page.date %}
         <i class='fa fa-group fa-fw'></i> <a href='/breakouts.html'> Breakout groups</a><br />
         <i class='fa fa-smile-o fa-fw'></i> <a href='/code-of-conduct.html'> Code of conduct</a><br />
@@ -138,15 +135,6 @@ layout: default
           <div itemprop="location" itemscope itemtype="http://schema.org/Place">
             <!-- <span itemprop="name">Chi Hack Night Zoom Call</span><br /> -->
             <span itemprop="name">Chi Hack Night YouTube Livestream</span><br />
-            <!-- <a href='https://maps.google.com/maps?q=222+W+Merchandise+Mart+Plz+Chicago'>
-              <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-                <span itemprop="streetAddress">222 W Merchandise Mart Plz
-                 <br />8th Floor</span><br />
-                <span itemprop="addressLocality">Chicago</span>,
-                <span itemprop="addressRegion">IL</span>
-              </div>
-            </a><br />
-            When you arrive in the Merchandise Mart, take the center elevators to the 8th floor. -->
           </div>
           
         </div>

--- a/_layouts/technexus_event.html
+++ b/_layouts/technexus_event.html
@@ -102,6 +102,20 @@ layout: default
           {% endif %}
 
         </p>
+      {% else %}
+        {% if page.speakers %}
+          {% if page.speakers.size > 1 %}
+            <strong>Presenters</strong>
+          {% else %}
+            <strong>Presenter</strong>
+          {% endif %}
+          <p>
+          {% for p in page.speakers %}
+            {{p}}<br />
+          {% endfor %}
+          </p>
+          <hr />
+        {% endif %}
       {% endif %}
 
       <span itemprop="description">{{content}}</span>

--- a/_posts/events/2024-02-20-pretrial-fairness-act.md
+++ b/_posts/events/2024-02-20-pretrial-fairness-act.md
@@ -6,7 +6,6 @@ links:
 title: "In-person and Online: Reducing Pretrial Jailing in Illinois - Implementing the Pretrial Fairness Act"
 description: "The Illinois Network for Pretrial Justice led the campaign to get the Illinois Pretrial Fairness Act law passed and is now working to hold the courts accountable to it. They’ll be presenting on the law, the fight to ensure successful implementation and the role data has played in reforming the state’s pretrial legal system."
 speakers:
- - "Briana Payton (she/her), Senior Policy Analyst, Chicago Appleseed"
  - "Matthew McLoughlin (he/him), Campaign Strategist, Illinois Network for Pretrial Justice" 
 image: /images/events/577-pretrial-fairness.jpg
 image_credit: 
@@ -23,17 +22,17 @@ published: true
 
 ---
 
+Last September, Illinois implemented the Pretrial Fairness Act and became the first state in the country to completely end the use of money bond. Since then the number of people incarcerated pretrial has begun to decrease across the state. 
+
+The Illinois Network for Pretrial Justice led the campaign to get this transformative law passed and is now working to hold the courts accountable to it. They’ll be presenting on the law, the fight to ensure successful implementation and the role data has played in reforming the state’s pretrial legal system. 
+
+---
+
 **This event will be in person, but you can also tune in via our usual livestream. Doors open at 6pm. The livestream and announcements will start around 6:30pm CDT.**
 
 **In-person:** <a href='https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198'>TeamWorking, 20 N Upper Wacker Drive, 12th Floor, Chicago IL</a>. Enter the Civic Opera Building using the entrance in the middle of the block between Washington and Madison streets. Take the elevators to the 12th floor.
 
 For more information on our in-person events, please see our [COVID Policy](/blog/2022/09/09/our-covid-19-policy.html). 
-
----
-
-Last September, Illinois implemented the Pretrial Fairness Act and became the first state in the country to completely end the use of money bond. Since then the number of people incarcerated pretrial has begun to decrease across the state. 
-
-The Illinois Network for Pretrial Justice led the campaign to get this transformative law passed and is now working to hold the courts accountable to it. They’ll be presenting on the law, the fight to ensure successful implementation and the role data has played in reforming the state’s pretrial legal system. 
 
 ---
 

--- a/_posts/events/2024-02-20-pretrial-fairness-act.md
+++ b/_posts/events/2024-02-20-pretrial-fairness-act.md
@@ -22,17 +22,17 @@ published: true
 
 ---
 
-Last September, Illinois implemented the Pretrial Fairness Act and became the first state in the country to completely end the use of money bond. Since then the number of people incarcerated pretrial has begun to decrease across the state. 
-
-The Illinois Network for Pretrial Justice led the campaign to get this transformative law passed and is now working to hold the courts accountable to it. They’ll be presenting on the law, the fight to ensure successful implementation and the role data has played in reforming the state’s pretrial legal system. 
-
----
-
 **This event will be in person, but you can also tune in via our usual livestream. Doors open at 6pm. The livestream and announcements will start around 6:30pm CDT.**
 
 **In-person:** <a href='https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198'>TeamWorking, 20 N Upper Wacker Drive, 12th Floor, Chicago IL</a>. Enter the Civic Opera Building using the entrance in the middle of the block between Washington and Madison streets. Take the elevators to the 12th floor.
 
 For more information on our in-person events, please see our [COVID Policy](/blog/2022/09/09/our-covid-19-policy.html). 
+
+---
+
+Last September, Illinois implemented the Pretrial Fairness Act and became the first state in the country to completely end the use of money bond. Since then the number of people incarcerated pretrial has begun to decrease across the state. 
+
+The Illinois Network for Pretrial Justice led the campaign to get this transformative law passed and is now working to hold the courts accountable to it. They’ll be presenting on the law, the fight to ensure successful implementation and the role data has played in reforming the state’s pretrial legal system. 
 
 ---
 

--- a/events/index.html
+++ b/events/index.html
@@ -8,7 +8,7 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
 <h1>
   Events
 </h1>
-<p>Past and upcoming Chi Hack Night presentations and events. We have hosted and recorded over 300 presentations since 2012. You can read about and watch them here.</p>
+<p>Past and upcoming Chi Hack Night presentations and events. We have hosted and recorded over 400 presentations since 2012. You can read about and watch them here.</p>
 
 <p>Have a talk you'd like to give at Chi Hack Night? <a href='/speaker-submissions.html'>Learn more about speaker submissions »</a></p>
 
@@ -20,6 +20,7 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
       <th>Event</th>
       <th>Speaker(s)</th>
       <th>Tags</th>
+      <th>Video</th>
     </tr>
   </thead>
   <tbody>
@@ -33,9 +34,6 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
           <td>{{post.event_id}}</td>
           <td>
             <a href='{{ post.url }}' itemprop='url'><span itemprop='name'>{{ post.title }}</span></a>
-            {% if post.youtube_id %}
-              <small><i title='This event has a video' class='fa fa-fw fa-video-camera'></i></small>
-            {% endif %}
           </td>
           <td>
             {% for speaker in post.speakers %}
@@ -46,6 +44,11 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
             {% for tag in post.tags %}
               {{tag}}<br />
             {% endfor %}
+          </td>
+          <td class='nowrap'>
+            {% if post.youtube_id %}
+              <a target="_blank" href='https://www.youtube.com/watch?v={{post.youtube_id}}'><i class='fa fa-fw fa-video-camera'></i> Watch</a>
+            {% endif %}
           </td>
         </tr>
       {% endif %}

--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@ layout: default
     <h3 class="panel-title"><b>Next Chi Hack Night</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
   </div>
   <div class="panel-body">
-    <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-    <h2 class='no-margin-top'>
-      <small>#{{post.event_id}}</small>
-      <a href="{{post.url}}">{{post.title}}</a>
-    </h2>
     <div class='row'>
       <div class='col-sm-7'>
+        <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
+        <h2 class='no-margin-top'>
+          <small>#{{post.event_id}}</small>
+          <a href="{{post.url}}">{{post.title}}</a>
+        </h2>
         {% if post.description %}
           <p>{{ post.description }}</p>
         {% endif %}
@@ -73,19 +73,27 @@ layout: default
     <h3 class="panel-title"><b>Last Chi Hack Night</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
   </div>
   <div class="panel-body">
-    <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-    <h2 class='no-margin-top'>
-      <small>#{{post.event_id}}</small>
-      <a href="{{post.url}}">{{post.title}}</a>
-    </h2>
     <div class='row'>
-      <div class='col-sm-12'>
+      <div class='col-sm-7'>
+        <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
+        <h2 class='no-margin-top'>
+          <small>#{{post.event_id}}</small>
+          <a href="{{post.url}}">{{post.title}}</a>
+        </h2>
         {% if post.description %}
           <p>{{ post.description }}</p>
         {% endif %}
         <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
         {% if post.youtube_id %}
         <a class='btn btn-link btn-lg' href="https://www.youtube.com/watch?v={{post.youtube_id}}" target='_blank'><i class='fa fa-play-circle'></i> YouTube Video</a>
+        {% endif %}
+      </div>
+      <div class='col-sm-5'>
+        {% if post.image and post.description.size > 0 %}
+          <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
+          {% if post.image_credit %}
+            <br /><small class='pull-right'><em>Photo: {{ post.image_credit }}</em></small>
+          {% endif %}
         {% endif %}
       </div>
     </div>
@@ -108,46 +116,7 @@ layout: default
       {% endfor %}
     </small>
   </div>
-  
 </div>
-
-<!--
-{% for post in site.categories['satellite']  limit:1 %}
-  {% if site.time <= post.date %}
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title"><b>Next Community Event</b></h3>
-      </div>
-      <div class="panel-body">
-        <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-
-        <h2 class='no-margin-top'>
-          <a href="{{post.url}}">{{post.title}}</a>
-        </h2>
-        <div class='row'>
-          <div class='col-sm-7'>
-            {% if post.description %}
-              <p>{{ post.description }}</p>
-            {% endif %}
-            <br />
-            {% if site.time <= post.date %}
-              <a class='btn btn-success btn-lg' href="{{post.rsvp}}" target='_blank'><i class='fa fa-check-square-o'></i> RSVP</a>
-            {% endif %}
-            <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
-            {% if page.agenda %}
-            <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'><i class='fa fa-file-text-o'></i> Agenda</a>
-            {% endif %}
-          </div>
-          <div class='col-sm-5'>
-            {% if post.image %}
-              <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </div>
-  {% endif %}
-{% endfor %} -->
 
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -163,6 +132,7 @@ layout: default
             {% else %}
               <img class='img-thumbnail img-responsive' src='/images/logo/logo.png' alt='{{ post.title }}' />
             {% endif %}
+            <br /><br />
           </div>
           <div class='col-sm-8'>
             <h4>
@@ -178,7 +148,6 @@ layout: default
               <br />
               {{ post.description | markdownify }} <a href='{{post.url}}'>Read&nbsp;more&nbsp;&raquo;</a>
             </p>
-            <br />
           </div>
         </div>
       {% endif %}

--- a/lib/events.js
+++ b/lib/events.js
@@ -6,6 +6,7 @@ var events_table = $('#hack-night-events').dataTable( {
         null,
         null,
         null,
+        null,
         null
     ],
     "bInfo": false,


### PR DESCRIPTION
This PR reduces the size of the left and right gutters / margins on the entire website and gives us a bit more width to work with.

* using `container-fluid` instead of `container` to reduce the size of the margins
* adds some additional margin for blog post layout to maintain readability
* using more width on home page for listing upcoming and past event
* adds extra breaks after images when listing blog posts

Other misc changes:
* with the additional width, adds a 'Video' column to more easily click off to watch event presentations
* updates presentation count to over 400 from 300
* adds presenter listing for `technexus_event` to make it consistent with `remote_event`
* removes some commented code
* removes speaker for event 577 that wasn't able to attend


## demo 
<img width="1490" alt="Screenshot 2024-02-23 at 2 47 53 PM" src="https://github.com/chihacknight/chihacknight.org/assets/919583/12b7ec5b-50c6-477a-851c-1cce4b23b666">
<img width="1492" alt="Screenshot 2024-02-23 at 2 48 04 PM" src="https://github.com/chihacknight/chihacknight.org/assets/919583/48924ea8-f9a3-4146-9239-2059130bea05">

