### PR TITLE
add zoom link logic for event and home page

### DIFF
--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -56,9 +56,13 @@ layout: default
               <hr />
             {% endif %}
           {% else %}
-            <a class='btn btn-link' href="https://bit.ly/chi-hack-night" target='_blank'><i class='fa fa-play-circle'></i> Live @ 7pm</a>
-          
-            <a class='btn btn-link' href="https://bit.ly/chi-hack-night" target='_blank'><i class='fa fa-play-circle'></i> Civic Hacking @ 8pm</a>
+            {% if page.remote_url %}
+              <a class='btn btn-link' href="{{page.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 7pm</a>
+            {% else %}
+              <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+
+              <a class='btn btn-link' href="https://bit.ly/chn-remote-zoom" target='_blank'><i class='fa fa-play-circle'></i> Civic Hacking @ 8pm</a>
+            {% endif %}
 
           {% endif %}
 
@@ -92,7 +96,13 @@ layout: default
               Announcements and feature presentation with Q&amp;A<br />
             </p>
             <ul>
-              <li>Join: <a href="https://youtube.com/chihacknight/live">https://youtube.com/chihacknight/live</a></li>
+              <li>Join: 
+                {% if page.remote_url %}
+                  <a href="{{page.remote_url}}">{{page.remote_url}}</a>
+                {% else %}
+                  <a href="https://youtube.com/chihacknight/live">https://youtube.com/chihacknight/live</a>
+                {% endif %}
+              </li>
               <li>YouTube automatic closed captioning will be available</li>
             </ul>
               
@@ -101,7 +111,14 @@ layout: default
               3-word intros, community announcements &amp; breakout group pitches<br />
             </p>
             <ul>
-              <li>Join: <a href="https://bit.ly/chn-remote-zoom">https://bit.ly/chn-remote-zoom</a></li>
+              <li>
+                Join: 
+                {% if page.remote_url %}
+                  <a href="{{page.remote_url}}">{{page.remote_url}}</a>
+                {% else %}
+                  <a href="https://bit.ly/chn-remote-zoom">https://bit.ly/chn-remote-zoom</a>
+                {% endif %}
+              </li>
               <li>Follow the agenda for <a href="{{page.agenda}}" target='_blank'>Intros, announcements and breakout groups</a></li>
               <li>After intros and announcements, we will break out into <a href='/breakouts.html'>learning and working groups</a></li>
             </ul>

--- a/_posts/events/2024-08-27-il-digital-equity.md
+++ b/_posts/events/2024-08-27-il-digital-equity.md
@@ -15,6 +15,7 @@ youtube_id:
 agenda: https://docs.google.com/document/d/14GtScQm0l6GyqdNht0LpqG8LmcEF7i3COjNJ06PaTj8/edit#
 sponsor: Chi Hack Night Community
 asl_provided: false
+remote_url: https://bit.ly/chi-hack-night
 tags: 
  - government
  - digital equity

--- a/index.html
+++ b/index.html
@@ -52,7 +52,11 @@ layout: default
             <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 6:30pm</a>
           {% endif %}
         {% else %}
-          <a class='btn btn-link btn-lg' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+          {% if post.remote_url %}
+            <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 7pm</a>
+          {% else %}
+            <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+          {% endif %}
         {% endif %}
         <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
       </div>


### PR DESCRIPTION
added logic on home page and `remote_event` layout to display the new zoom link when `remote_url` variable is set for an event. still defaults the old links if no value is set.