### PR TITLE
remove flickr

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -124,34 +124,3 @@ layout: default
     {% endif %}
   </div>
 </div>
-
-<div class='row'>
-  <div class='col-sm-12'>
-
-    <hr />
-    <h4 id='slideshow-header' style='display: none;'>Flickr photos from Chi Hack Night #{{page.event_id}}</h4>
-    <div class='slideshow'></div>
-    <p>Have a photo of this event? Upload it to <a href='http://flickr.com'>Flickr</a> and tag it with <strong><a href='https://www.flickr.com/search/?tags=chihacknight{{page.event_id}}'>chihacknight{{page.event_id}}</a></strong></p>
-
-    <script src="/js/galleria/galleria.js"></script>
-    <script src="/js/galleria/plugins/flickr/galleria.flickr.js"></script>
-    <script>
-      var flickr = new Galleria.Flickr();
-        flickr.tags('chihacknight-{{page.event_id}}, chihacknight{{page.event_id}}', function(data) {
-            // Should we show or hide the slideshow?
-            var $slideshow = $(".slideshow");
-            if (data.length) {
-              $slideshow.css({height: 600, marginBottom: 20});
-              $('#slideshow-header').show()
-            } else {
-              $slideshow.hide();
-            }
-
-            Galleria.loadTheme('/js/galleria/themes/classic/galleria.classic.js');
-            Galleria.run('.slideshow', {
-                dataSource: data
-            });
-        });
-    </script>
-  </div>
-</div>

--- a/_layouts/icstars_event.html
+++ b/_layouts/icstars_event.html
@@ -156,36 +156,5 @@ layout: default
         </div>
       </div>
     </div>
-
-    <div class='row'>
-      <div class='col-sm-12'>
-
-        <hr />
-        <h4 id='slideshow-header' style='display: none;'>Flickr photos from Chi Hack Night #{{page.event_id}}</h4>
-        <div class='slideshow'></div>
-        <p>Have a photo of this event? Upload it to <a href='http://flickr.com'>Flickr</a> and tag it with <strong><a href='https://www.flickr.com/search/?tags=chihacknight{{page.event_id}}'>chihacknight{{page.event_id}}</a></strong></p>
-
-        <script src="/js/galleria/galleria.js"></script>
-        <script src="/js/galleria/plugins/flickr/galleria.flickr.js"></script>
-        <script>
-          var flickr = new Galleria.Flickr();
-            flickr.tags('chihacknight-{{page.event_id}}, chihacknight{{page.event_id}}', function(data) {
-                // Should we show or hide the slideshow?
-                var $slideshow = $(".slideshow");
-                if (data.length) {
-                  $slideshow.css({height: 600, marginBottom: 20});
-                  $('#slideshow-header').show()
-                } else {
-                  $slideshow.hide();
-                }
-
-                Galleria.loadTheme('/js/galleria/themes/classic/galleria.classic.js');
-                Galleria.run('.slideshow', {
-                    dataSource: data
-                });
-            });
-        </script>
-      </div>
-    </div>
   </div>
 </div>

--- a/_layouts/technexus_event.html
+++ b/_layouts/technexus_event.html
@@ -156,36 +156,5 @@ layout: default
         </div>
       </div>
     </div>
-
-    <div class='row'>
-      <div class='col-sm-12'>
-
-        <hr />
-        <h4 id='slideshow-header' style='display: none;'>Flickr photos from Chi Hack Night #{{page.event_id}}</h4>
-        <div class='slideshow'></div>
-        <p>Have a photo of this event? Upload it to <a href='http://flickr.com'>Flickr</a> and tag it with <strong><a href='https://www.flickr.com/search/?tags=chihacknight{{page.event_id}}'>chihacknight{{page.event_id}}</a></strong></p>
-
-        <script src="/js/galleria/galleria.js"></script>
-        <script src="/js/galleria/plugins/flickr/galleria.flickr.js"></script>
-        <script>
-          var flickr = new Galleria.Flickr();
-            flickr.tags('chihacknight-{{page.event_id}}, chihacknight{{page.event_id}}', function(data) {
-                // Should we show or hide the slideshow?
-                var $slideshow = $(".slideshow");
-                if (data.length) {
-                  $slideshow.css({height: 600, marginBottom: 20});
-                  $('#slideshow-header').show()
-                } else {
-                  $slideshow.hide();
-                }
-
-                Galleria.loadTheme('/js/galleria/themes/classic/galleria.classic.js');
-                Galleria.run('.slideshow', {
-                    dataSource: data
-                });
-            });
-        </script>
-      </div>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
On our event pages, we have used flickr to host photos. It looks like flickr requires an API key now to access photos.

<img width="537" height="135" alt="Screenshot 2025-07-15 at 4 35 34 PM" src="https://github.com/user-attachments/assets/4a135935-091e-4670-a0a8-1f683d1a77f7" />

To remove the error message, this PR removes the flickr component from the event templates