### PR TITLE
Split Up Events Page & Tweak Some Styling

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -7,8 +7,8 @@ layout: default
     <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
   </h3>
   <h1>
-    <small>#{{page.event_id}}</small>
     <span itemprop="name">{{page.title}}</span>
+    <small>#{{page.event_id}}</small>
   </h1>
   <hr />
 
@@ -16,7 +16,7 @@ layout: default
     {% if site.time <= page.date %}
       <div class='col-sm-7'>
     {% else %}
-      <div class='col-sm-12'> 
+      <div class='col-sm-12'>
     {% endif %}
 
       {% if page.youtube_id %}
@@ -103,7 +103,7 @@ layout: default
             {% endfor %}
             </p>
           {% endif %}
-         
+
           <strong>Location</strong><br />
           {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
           <div itemprop="location" itemscope itemtype="http://schema.org/Place">
@@ -118,7 +118,7 @@ layout: default
             </a><br />
             When you arrive in the Merchandise Mart, take the center elevators to the 8th floor.
           </div>
-          
+
         </div>
       </div>
     {% endif %}

--- a/_layouts/icstars_event.html
+++ b/_layouts/icstars_event.html
@@ -9,8 +9,8 @@ layout: default
         <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
       </h3>
       <h1>
-        <small>#{{page.event_id}}</small>
         <span itemprop="name">{{page.title}}</span>
+        <small>#{{page.event_id}}</small>
       </h1>
       <hr />
 
@@ -39,7 +39,7 @@ layout: default
                 {% endfor %}
                 </p>
               {% endif %}
-            
+
               <strong>Location</strong><br />
               {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
               <div itemprop="location" itemscope itemtype="http://schema.org/Place">
@@ -61,14 +61,14 @@ layout: default
                 <span itemprop="name">Also on the Chi Hack Night <a href="https://youtube.com/chihacknight/live">YouTube Livestream</a></span><br />
               {% endif %}
               </div>
-              
+
             </div>
           </div>
         {% endif %}
         {% if site.time <= page.date %}
           <div class='col-sm-7 col-sm-pull-5'>
         {% else %}
-          <div class='col-sm-12'> 
+          <div class='col-sm-12'>
         {% endif %}
 
           {% if page.youtube_id %}

--- a/_layouts/remote_event.html
+++ b/_layouts/remote_event.html
@@ -9,8 +9,8 @@ layout: default
         <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
       </h3>
       <h1>
-        <small>#{{page.event_id}}</small>
         <span itemprop="name">{{page.title}}</span>
+        <small>#{{page.event_id}}</small>
       </h1>
       <hr />
 
@@ -18,7 +18,7 @@ layout: default
         {% if site.time <= page.date %}
           <div class='col-sm-7'>
         {% else %}
-          <div class='col-sm-12'> 
+          <div class='col-sm-12'>
         {% endif %}
 
           {% if page.youtube_id %}
@@ -96,7 +96,7 @@ layout: default
               Announcements and feature presentation with Q&amp;A<br />
             </p>
             <ul>
-              <li>Join: 
+              <li>Join:
                 {% if page.remote_url %}
                   <a href="{{page.remote_url}}">{{page.remote_url}}</a>
                 {% else %}
@@ -105,14 +105,14 @@ layout: default
               </li>
               <!-- <li>YouTube automatic closed captioning will be available</li> -->
             </ul>
-              
+
             <p>
               <strong>8:00pm - Civic hacking</strong><br />
               3-word intros, community announcements &amp; breakout group pitches<br />
             </p>
             <ul>
               <li>
-                Join: 
+                Join:
                 {% if page.remote_url %}
                   <a href="{{page.remote_url}}">{{page.remote_url}}</a>
                 {% else %}
@@ -149,14 +149,14 @@ layout: default
                 {% endfor %}
                 </p>
               {% endif %}
-            
+
               <strong>Location</strong><br />
               {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
               <div itemprop="location" itemscope itemtype="http://schema.org/Place">
                 <span itemprop="name">Chi Hack Night Zoom Call</span><br />
                 <!-- <span itemprop="name">Chi Hack Night YouTube Livestream</span><br /> -->
               </div>
-              
+
             </div>
           </div>
         {% endif %}

--- a/_layouts/remote_event_openhack.html
+++ b/_layouts/remote_event_openhack.html
@@ -8,8 +8,8 @@ layout: default
         <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
       </h3>
       <h1>
-        <small>#{{page.event_id}}</small>
         <span itemprop="name">{{page.title}}</span>
+        <small>#{{page.event_id}}</small>
       </h1>
       <hr />
 
@@ -17,7 +17,7 @@ layout: default
         {% if site.time <= page.date %}
           <div class='col-sm-7'>
         {% else %}
-          <div class='col-sm-12'> 
+          <div class='col-sm-12'>
         {% endif %}
 
           {% if page.youtube_id %}
@@ -121,7 +121,7 @@ layout: default
                 {% endfor %}
                 </p>
               {% endif %}
-            
+
               <strong>Location</strong><br />
               {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
               <div itemprop="location" itemscope itemtype="http://schema.org/Place">

--- a/_layouts/remote_member_only.html
+++ b/_layouts/remote_member_only.html
@@ -9,8 +9,8 @@ layout: default
         <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
       </h3>
       <h1>
-        <small>#{{page.event_id}}</small>
         <span itemprop="name">{{page.title}}</span>
+        <small>#{{page.event_id}}</small>
       </h1>
       <hr />
 

--- a/_layouts/technexus_event.html
+++ b/_layouts/technexus_event.html
@@ -9,8 +9,8 @@ layout: default
         <a href='/events'>Events</a> > <time itemprop="startDate" datetime={{ page.date | date: "%Y-%m-%d" }}>{{ page.date | date: "%B %-d, %Y" }}</time>
       </h3>
       <h1>
-        <small>#{{page.event_id}}</small>
         <span itemprop="name">{{page.title}}</span>
+        <small>#{{page.event_id}}</small>
       </h1>
       <hr />
 
@@ -39,7 +39,7 @@ layout: default
                 {% endfor %}
                 </p>
               {% endif %}
-            
+
               <strong>Location</strong><br />
               {{ page.date | date: "%l:%M%P" }} {{ page.date | date: "%A, %B %-d, %Y" }}
               <div itemprop="location" itemscope itemtype="http://schema.org/Place">
@@ -61,14 +61,14 @@ layout: default
                 <span itemprop="name">Also on the Chi Hack Night <a href="https://youtube.com/chihacknight/live">YouTube Livestream</a></span><br />
               {% endif %}
               </div>
-              
+
             </div>
           </div>
         {% endif %}
         {% if site.time <= page.date %}
           <div class='col-sm-7 col-sm-pull-5'>
         {% else %}
-          <div class='col-sm-12'> 
+          <div class='col-sm-12'>
         {% endif %}
 
           {% if page.youtube_id %}

--- a/css/custom.css
+++ b/css/custom.css
@@ -8,12 +8,12 @@ body {
 
 .navbar-brand img { height: 40px; }
 
-.navbar-nav > li > a { 
+.navbar-nav > li > a {
   padding: 10px;
   font-size: 0.9em;
 }
 
-.navbar-nav { 
+.navbar-nav {
   padding-top: 60px;
   margin-right: 0px;
 }
@@ -35,8 +35,25 @@ a { text-decoration: none !important; }
   text-decoration: none;
 }
 
-.no-margin-top{
-  margin-top: 0px;
+/** 25% bigger text helper */
+.large-text {
+  font-size: 1.25em;
+}
+
+/** 50% bigger text helper */
+.x-large-text {
+  font-size: 1.5em;
+}
+
+.no-margin-top {
+  margin-top: 0;
+}
+
+/** Ensure panel titles handle varied text sizes */
+.panel-title {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
 }
 
 .muted { color: #999; }

--- a/css/custom.css
+++ b/css/custom.css
@@ -45,6 +45,11 @@ a { text-decoration: none !important; }
   font-size: 1.5em;
 }
 
+/** Fixes default Bootstrap3 small color failing WCAG contrast checks */
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+  small, .small { color: #757676; }
+}
+
 .no-margin-top {
   margin-top: 0;
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -66,15 +66,41 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   justify-content: space-between;
 }
 
-.muted { color: #999; }
+.muted { color: #757676; }
 .img-home-teaser { margin-top: 60px;}
 
+/** Create custom white buttons with faint red borders */
 .btn-link {
   color: #E7121C;
+  border: solid 3px #ff00002e;
+  transition: color 0.3s, background-color 0.3s;
+  border-radius: 6px;
 }
 
-.btn-link:hover {
+.btn-link, .btn-lg {
+  /** Increase link icon visibility and spacing */
+  .fa {
+    margin-right: 5px;
+    font-size: 1.25em;
+    vertical-align: middle;
+  }
+}
+
+.btn-link:hover, .btn-link:focus {
   color: #980c12;
+  border: solid 3px #ff00002e;
+  background-color: #ffeded;
+}
+
+/** Custom styling for homepage event buttons */
+.btn-row {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.btn-row .btn-lg {
+  padding: 10px 25px;
 }
 
 .btn-success {

--- a/css/custom.css
+++ b/css/custom.css
@@ -50,6 +50,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   small, .small { color: #757676; }
 }
 
+.event-title {
+  font-weight: bold;
+  margin-top: 5px;
+}
+
 .no-margin-top {
   margin-top: 0;
 }

--- a/events/index.html
+++ b/events/index.html
@@ -12,7 +12,24 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
 
 <p>Have a talk you'd like to give at Chi Hack Night? <a href='/speaker-submissions.html'>Learn more about speaker submissions »</a></p>
 
-<table id='hack-night-events' class='table table-striped'>
+{% assign upcoming_events = '' | split: '' %}
+{% assign past_events = '' | split: '' %}
+{% assign current_date = 'now' | date: '%s' %}
+
+{% for post in site.posts %}
+  {% if post.categories contains 'events' or post.categories contains 'satellite' %}
+    {% assign post_date = post.date | date: '%s' %}
+    {% if post_date >= current_date %}
+      {% assign upcoming_events = upcoming_events | push: post %}
+    {% else %}
+      {% assign past_events = past_events | push: post %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+<h2>Upcoming Events</h2>
+{% if upcoming_events.size > 0 %}
+<table id='upcoming-events' class='table table-striped'>
   <thead>
     <tr itemscope itemtype='http://schema.org/Event'>
       <th>Date</th>
@@ -24,8 +41,7 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
     </tr>
   </thead>
   <tbody>
-    {% for post in site.posts %}
-      {% if post.categories contains 'events' or post.categories contains 'satellite' %}
+    {% for post in upcoming_events reversed %}
         <tr>
           <td class='nowrap'>
               <meta itemprop='startDate' datetime='{{ post.date | date: "%Y-%m-%d" }}' content='{{ post.date | date: "%Y-%m-%d" }}' />
@@ -51,7 +67,52 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
             {% endif %}
           </td>
         </tr>
-      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No upcoming events scheduled at this time.</p>
+{% endif %}
+
+<h2>Past Events</h2>
+<table id='past-events' class='table table-striped'>
+  <thead>
+    <tr itemscope itemtype='http://schema.org/Event'>
+      <th>Date</th>
+      <th>#</th>
+      <th>Event</th>
+      <th>Speaker(s)</th>
+      <th>Tags</th>
+      <th>Video</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for post in past_events %}
+        <tr>
+          <td class='nowrap'>
+              <meta itemprop='startDate' datetime='{{ post.date | date: "%Y-%m-%d" }}' content='{{ post.date | date: "%Y-%m-%d" }}' />
+              <p>{{ post.date | date: "%b %-d, %Y" }}</p>
+          </td>
+          <td>{{post.event_id}}</td>
+          <td>
+            <a href='{{ post.url }}' itemprop='url'><span itemprop='name'>{{ post.title }}</span></a>
+          </td>
+          <td>
+            {% for speaker in post.speakers %}
+              {{speaker}}<br />
+            {% endfor %}
+          </td>
+          <td class='nowrap'>
+            {% for tag in post.tags %}
+              {{tag}}<br />
+            {% endfor %}
+          </td>
+          <td class='nowrap'>
+            {% if post.youtube_id %}
+              <a target="_blank" href='https://www.youtube.com/watch?v={{post.youtube_id}}'><i class='fa fa-fw fa-video-camera'></i> Watch</a>
+            {% endif %}
+          </td>
+        </tr>
     {% endfor %}
   </tbody>
 </table>

--- a/events/index.html
+++ b/events/index.html
@@ -71,7 +71,7 @@ description: Past and upcoming Chi Hack Night presentations and events. We have 
   </tbody>
 </table>
 {% else %}
-<p>No upcoming events scheduled at this time.</p>
+<p>We haven't listed more upcoming events yet, check back later!</p>
 {% endif %}
 
 <h2>Past Events</h2>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
     <div class='row'>
       <div class='col-sm-7'>
         <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-        <h2 class='event-title no-margin-top'>
+        <h2 class='event-title'>
           <a href="{{post.url}}">{{post.title}}</a>
           <small> #{{post.event_id}}</small>
         </h2>
@@ -88,7 +88,7 @@ layout: default
     <div class='row'>
       <div class='col-sm-7'>
         <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-        <h2 class='event-title no-margin-top'>
+        <h2 class='event-title'>
           <a href="{{post.url}}">{{post.title}}</a>
           <small> #{{post.event_id}}</small>
         </h2>

--- a/index.html
+++ b/index.html
@@ -35,33 +35,40 @@ layout: default
           <a href="{{post.url}}">{{post.title}}</a>
           <small> #{{post.event_id}}</small>
         </h2>
+
         {% if post.description %}
           <p>{{ post.description }}</p>
         {% endif %}
-        <br />
-        {% if post.rsvp_url %}
-          <a class='btn btn-success' href='{{post.rsvp_url}}'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
-        {% endif %}
-        <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
-        {% if post.layout == "remote_event_openhack" %}
-          <a class='btn btn-link btn-lg' href="https://bit.ly/chi-hack-night" target='_blank'><i class='fa fa-play-circle'></i> Chi Hack Night Zoom Call @ 7pm</a>
-        {% elsif post.layout == "technexus_event"  %}
-          <a class='btn btn-link btn-lg' href="https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198" target='_blank'><i class='fa fa-map-marker'></i> TechNexus</a>
 
-          {% if post.remote_url %}
-            <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 6:30pm</a>
-          {% else %}
-            <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 6:30pm</a>
+        <br />
+
+        <div class="btn-row">
+          <!-- TODO: Remove || true, this is for testing -->
+          {% if post.rsvp_url or true %}
+            <a class='btn btn-lg btn-success' href='{{post.rsvp_url}}'><i class='fa fa-check-square-o'></i> RSVP (required)</a>
           {% endif %}
-        {% else %}
-          {% if post.remote_url %}
-            <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 7pm</a>
+          <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
+          {% if post.layout == "remote_event_openhack" %}
+            <a class='btn btn-link btn-lg' href="https://bit.ly/chi-hack-night" target='_blank'><i class='fa fa-play-circle'></i> Chi Hack Night Zoom Call @ 7pm</a>
+          {% elsif post.layout == "technexus_event"  %}
+            <a class='btn btn-link btn-lg' href="https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198" target='_blank'><i class='fa fa-map-marker'></i> TechNexus</a>
+
+            {% if post.remote_url %}
+              <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 6:30pm</a>
+            {% else %}
+              <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 6:30pm</a>
+            {% endif %}
           {% else %}
-            <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+            {% if post.remote_url %}
+              <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 7pm</a>
+            {% else %}
+              <a class='btn btn-link' href="https://youtube.com/chihacknight/live" target='_blank'><i class='fa fa-play-circle'></i> Livestream @ 7pm</a>
+            {% endif %}
           {% endif %}
-        {% endif %}
-        <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
+          <a class='btn btn-link btn-lg' href="{{post.agenda}}" target='_blank'>Agenda</a>
+        </div>
       </div>
+
       <div class='col-sm-5'>
         {% if post.image and post.description.size > 0 %}
           <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
@@ -92,17 +99,24 @@ layout: default
           <a href="{{post.url}}">{{post.title}}</a>
           <small> #{{post.event_id}}</small>
         </h2>
+
         {% if post.description %}
           <p>{{ post.description }}</p>
         {% endif %}
-        <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
-        {% if post.youtube_id %}
-        <a class='btn btn-link btn-lg' href="https://www.youtube.com/watch?v={{post.youtube_id}}" target='_blank'><i class='fa fa-play-circle'></i> YouTube Video</a>
-        {% endif %}
+
+        <div class="btn-row">
+          <a class='btn btn-link btn-lg' href="{{post.url}}"><i class='fa fa-info-circle-square-o'></i> Details</a>
+
+          {% if post.youtube_id %}
+            <a class='btn btn-link btn-lg' href="https://www.youtube.com/watch?v={{post.youtube_id}}" target='_blank'><i class='fa fa-play-circle'></i> YouTube Video</a>
+          {% endif %}
+        </div>
       </div>
+
       <div class='col-sm-5'>
         {% if post.image and post.description.size > 0 %}
           <a href="{{post.url}}"><img class='img-responsive img-thumbnail' src='{{post.image}}' alt='{{post.title}}' /></a>
+
           {% if post.image_credit %}
             <br /><small class='pull-right'><em>Photo: {{ post.image_credit }}</em></small>
           {% endif %}

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ layout: default
         {% if post.layout == "remote_event_openhack" %}
           <a class='btn btn-link btn-lg' href="https://bit.ly/chi-hack-night" target='_blank'><i class='fa fa-play-circle'></i> Chi Hack Night Zoom Call @ 7pm</a>
         {% elsif post.layout == "technexus_event"  %}
-          <a class='btn btn-link btn-lg' href="https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198" target='_blank'><i class='fa fa-map-marker'></i> TechNexus</a>  
+          <a class='btn btn-link btn-lg' href="https://www.google.com/maps/place/TechNexus+Venture+Collaborative/@41.8835673,-87.6394085,17z/data=!3m1!4b1!4m5!3m4!1s0x880e2d5be57f04c5:0xa87e47e177660090!8m2!3d41.8835673!4d-87.6372198" target='_blank'><i class='fa fa-map-marker'></i> TechNexus</a>
 
           {% if post.remote_url %}
             <a class='btn btn-link' href="{{post.remote_url}}" target='_blank'><i class='fa fa-play-circle'></i> Zoom @ 6:30pm</a>
@@ -69,7 +69,7 @@ layout: default
         {% endif %}
       </div>
     </div>
-      
+
   </div>
 </div>
 {% endfor %}
@@ -105,7 +105,7 @@ layout: default
         {% endif %}
       </div>
     </div>
-      
+
   </div>
 </div>
 {% endfor %}
@@ -113,16 +113,20 @@ layout: default
 {% assign future_events = upcoming_posts | shift %}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title"><b>Upcoming Events</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
+    <h3 class="panel-title"><b>More Upcoming Events</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
   </div>
   <div class="panel-body">
+    {% if future_events.size > 0 %}
     <small>
       {% for post in future_events %}
-      {{ post.date | date: "%A, %B %-d, %Y" }} {{ post.date | date: "%l:%M%P" }} 
+      {{ post.date | date: "%A, %B %-d, %Y" }} {{ post.date | date: "%l:%M%P" }}
       <a href="{{post.url}}">{{post.title}}</a>
       <br />
       {% endfor %}
     </small>
+    {% else %}
+    <p>We haven't listed more upcoming events yet, check back later!</p>
+    {% endif %}
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,9 @@ layout: default
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title"><b>Next Chi Hack Night</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
+    <h3 class="panel-title">
+      <b class="x-large-text">Next Chi Hack Night</b> <a class='pull-right' href='/events/'>All events &raquo;</a>
+    </h3>
   </div>
   <div class="panel-body">
     <div class='row'>
@@ -78,7 +80,9 @@ layout: default
 {% for post in past_events limit: 1 %}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title"><b>Last Chi Hack Night</b> <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
+    <h3 class="panel-title">
+      <b class="large-text">Last Chi Hack Night</b>
+      <a class='pull-right' href='/events/'>All events &raquo;</a></h3>
   </div>
   <div class="panel-body">
     <div class='row'>

--- a/index.html
+++ b/index.html
@@ -31,9 +31,9 @@ layout: default
     <div class='row'>
       <div class='col-sm-7'>
         <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-        <h2 class='no-margin-top'>
-          <small>#{{post.event_id}}</small>
+        <h2 class='event-title no-margin-top'>
           <a href="{{post.url}}">{{post.title}}</a>
+          <small> #{{post.event_id}}</small>
         </h2>
         {% if post.description %}
           <p>{{ post.description }}</p>
@@ -88,9 +88,9 @@ layout: default
     <div class='row'>
       <div class='col-sm-7'>
         <strong>{{ post.date | date: "%l:%M%P" }} {{ post.date | date: "%A, %B %-d, %Y" }}</strong>
-        <h2 class='no-margin-top'>
-          <small>#{{post.event_id}}</small>
+        <h2 class='event-title no-margin-top'>
           <a href="{{post.url}}">{{post.title}}</a>
+          <small> #{{post.event_id}}</small>
         </h2>
         {% if post.description %}
           <p>{{ post.description }}</p>


### PR DESCRIPTION
I started with the goal to split up the events page by upcoming and past, to fix confusion when multiple upcoming events are listed. But I also ended up making some cosmetic tweaks to the homepage to improve visual clarity and hierarchy and fix some contrast failures with light grey text - feel free to ask me to revert any changes!

My main motivations boil down to:

1. **Make the most important thing biggest, boldest, and first** - this meant making the homepage event titles bold, making the upcoming events section more prominent, and moving the event ID _after_ titles. This last changes also improves alignment
2. **Make alignment solid** - in this direction I added button borders, which makes it so whitespace that was interactive is clearly demarcated, and makes the alignment look more proper

**If y'all disagree with any cosmetic changes - let me know, and I'll remove them!** I think they overall all improve readability and clarity, but I'm just one person!

| Page | Before | After |
| --- | --- | --- |
| Homepage | <img width="1632" height="1030" alt="image" src="https://github.com/user-attachments/assets/efd17dc0-dfad-474d-b263-bb0b50bf0056" /> | <img width="1632" height="1030" alt="image" src="https://github.com/user-attachments/assets/740851ea-9b8f-4877-b152-abaccd408228" /> |
| Events Page | <img width="1623" height="768" alt="image" src="https://github.com/user-attachments/assets/ba843eaf-4c3f-4e3c-a67c-dbb42cbc7923" /> | <img width="1623" height="768" alt="Screenshot from 2025-08-15 22-12-31" src="https://github.com/user-attachments/assets/0d01771a-2504-4bb8-b7b1-258670b33aa9" /> |
| Event Page | <img width="1623" height="768" alt="Screenshot from 2025-08-15 22-11-49" src="https://github.com/user-attachments/assets/7b53010b-369f-4dfd-ad2a-73cfaa43c010" /> | <img width="1623" height="768" alt="image" src="https://github.com/user-attachments/assets/3cd5e4e2-1e6d-4326-9fce-c9831b06f2f1" /> |