### PR TITLE
adds workflow to trigger build every tuesday night

### DIFF
--- a/.github/weekly_deploy.yml
+++ b/.github/weekly_deploy.yml
@@ -1,0 +1,20 @@
+name: Weekly Deploy
+permissions:
+  content: write
+on:
+  schedule:
+  # 9PM Central on Tuesday = 3 AM UTC on Wednesday
+    - cron: "0 3 * * 3"
+jobs:
+  triggger-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make empty commit to trigger built
+        run: |
+          git config user.name "chi hack night ci automation"
+          git commit user.email "sneha@chihacknight.org"
+          git commit --allow-empty -m "Chi Hack Night CI Automation: Weekly Trigger Build"
+          git push

--- a/.github/weekly_deploy.yml
+++ b/.github/weekly_deploy.yml
@@ -3,7 +3,7 @@ permissions:
   content: write
 on:
   schedule:
-  # 9PM Central on Tuesday = 3 AM UTC on Wednesday
+  # 9pm CST/10pm CDT = 3 AM UTC on Wednesday
     - cron: "0 3 * * 3"
 jobs:
   triggger-build:


### PR DESCRIPTION
Every Tuesday night after Chi Hack Night, we need to trigger a build in order to update the layout to show our next event prominently instead of that week's event. Previously, someone either logged into Netlify to do this manually, or added a commit to trigger a build.

This automates that process with github actions and a cron job, so the build is triggered automatically every Tuesday at 9pm CT.